### PR TITLE
NETTE a NETTE_* konstanty

### DIFF
--- a/Nette/Debug/templates/bluescreen.phtml
+++ b/Nette/Debug/templates/bluescreen.phtml
@@ -154,7 +154,7 @@ static $errorTypes = array(
 
 $title = ($exception instanceof \FatalErrorException && isset($errorTypes[$exception->getSeverity()])) ? $errorTypes[$exception->getSeverity()] : get_class($exception);
 
-$expandPath = NETTE_DIR . DIRECTORY_SEPARATOR; // . 'Utils' . DIRECTORY_SEPARATOR . 'Object';
+$expandPath = Nette\DIR . DIRECTORY_SEPARATOR; // . 'Utils' . DIRECTORY_SEPARATOR . 'Object';
 
 if (headers_sent()) {
 	echo '</pre></xmp></table>';

--- a/Nette/Loaders/NetteLoader.php
+++ b/Nette/Loaders/NetteLoader.php
@@ -225,7 +225,7 @@ class NetteLoader extends AutoLoader
 	{
 		$type = ltrim(strtolower($type), '\\');
 		if (isset($this->list[$type])) {
-			LimitedScope::load(NETTE_DIR . $this->list[$type]);
+			LimitedScope::load(Nette\DIR . $this->list[$type]);
 			self::$count++;
 		}
 	}

--- a/Nette/Utils/Tools.php
+++ b/Nette/Utils/Tools.php
@@ -174,9 +174,9 @@ final class Tools
 		if (self::$criticalSections) {
 			throw new \InvalidStateException('Critical section has already been entered.');
 		}
-		$handle = fopen(NETTE_DIR . '/lockfile', 'r') ?: fopen(NETTE_DIR . '/lockfile', 'w');
+		$handle = fopen(Nette\DIR . '/lockfile', 'r') ?: fopen(Nette\DIR . '/lockfile', 'w');
 		if (!$handle) {
-			throw new \InvalidStateException("Unable initialize critical section (missing file '" . NETTE_DIR . "/lockfile').");
+			throw new \InvalidStateException("Unable initialize critical section (missing file '" . Nette\DIR . "/lockfile').");
 		}
 		flock(self::$criticalSections = $handle, LOCK_EX);
 	}

--- a/Nette/loader.php
+++ b/Nette/loader.php
@@ -9,7 +9,7 @@
  * GPL license. For more information please see http://nette.org
  */
 
-
+namespace Nette;
 
 /**
  * Check and reset PHP configuration.
@@ -36,10 +36,10 @@ extension_loaded('mbstring') && mb_internal_encoding('UTF-8');
 /**
  * Load and configure Nette Framework
  */
-define('NETTE', TRUE);
-define('NETTE_DIR', __DIR__);
-define('NETTE_VERSION_ID', 20000); // v2.0.0
-define('NETTE_PACKAGE', '5.3');
+const IS_PRESENT = TRUE;
+const DIR = __DIR__;
+const VERSION_ID = 20000; // v2.0.0
+const PACKAGE = '5.3';
 
 
 
@@ -54,4 +54,4 @@ require_once __DIR__ . '/Loaders/AutoLoader.php';
 require_once __DIR__ . '/Loaders/NetteLoader.php';
 
 
-Nette\Loaders\NetteLoader::getInstance()->register();
+Loaders\NetteLoader::getInstance()->register();


### PR DESCRIPTION
Konstanty NETTE_\* by měly být v namespace Nette, to, že jsou v globálním prostoru nedává smysl.
Nette\IS_PRESENT (NIS_PRESENT v prefixed, původně NETTE)
Nette\DIR (NDIR v prefixed, původně NETTE_DIR)
Nette\VERSION_ID (NVERSION_ID v prefixed, původně NETTE_VERSION_ID)
Nette\PACKAGE (NPACKAGE v prefixed, původně NETTE_PACKAGE)
