### PR TITLE
Chybove texty vynimiek

### DIFF
--- a/Nette/Application/Control.php
+++ b/Nette/Application/Control.php
@@ -45,7 +45,7 @@ abstract class Control extends PresenterComponent implements IPartiallyRenderabl
 			$value = $this->createTemplate();
 			if (!($value instanceof Nette\Templates\ITemplate || $value === NULL)) {
 				$class = get_class($value);
-				throw new \UnexpectedValueException("Object returned by {$this->reflection->name}::createTemplate() must be instance of Nette\\Templates\\ITemplate, '$class' given.");
+				throw new \UnexpectedValueException("Object returned by {$this->reflection->name}::createTemplate() must be instance of " . 'Nette\Templates\ITemplate' . ", '$class' given.");
 			}
 			$this->template = $value;
 		}

--- a/Nette/Application/PresenterLoader.php
+++ b/Nette/Application/PresenterLoader.php
@@ -77,7 +77,7 @@ class PresenterLoader implements IPresenterLoader
 		$class = $reflection->getName();
 
 		if (!$reflection->implementsInterface('Nette\Application\IPresenter')) {
-			throw new InvalidPresenterException("Cannot load presenter '$name', class '$class' is not Nette\\Application\\IPresenter implementor.");
+			throw new InvalidPresenterException("Cannot load presenter '$name', class '$class' is not " . 'Nette\Application\IPresenter' . " implementor.");
 		}
 
 		if ($reflection->isAbstract()) {

--- a/Nette/Config/Config.php
+++ b/Nette/Config/Config.php
@@ -42,7 +42,7 @@ class Config implements \ArrayAccess, \IteratorAggregate
 		}
 
 		if (!Nette\Reflection\ClassReflection::from($class)->implementsInterface('Nette\Config\IConfigAdapter')) {
-			throw new \InvalidArgumentException("Configuration adapter '$class' is not Nette\\Config\\IConfigAdapter implementor.");
+			throw new \InvalidArgumentException("Configuration adapter '$class' is not " . 'Nette\Config\IConfigAdapter' . " implementor.");
 		}
 
 		self::$extensions[strtolower($extension)] = $class;

--- a/Nette/Environment/Environment.php
+++ b/Nette/Environment/Environment.php
@@ -353,7 +353,7 @@ final class Environment
 		if (isset(self::$aliases[$name])) {
 			return self::getContext()->getService(self::$aliases[$name], $args);
 		} else {
-			throw new \MemberAccessException("Call to undefined static method Nette\\Environment::$name().");
+			throw new \MemberAccessException("Call to undefined static method " . 'Nette\Environment' . "::$name().");
 		}
 	}
 


### PR DESCRIPTION
Dnes ked som opravoval chybku v LatteMacros.php som pochopil single a double backslashe v zdrojakoch... bolo mi chvilu divne preco nie su jednotne napriec frameworkom...

Ale k veci: nebolo zle, keby vynimky hlasili meno classy take, ake v danej packagi je, nie natvrdo to s namespacom. Nemam to ako vyskusat (nemam generator verzii), ale podla mojich vypoctov by tento commit mohol pomoct...

kravčo
