### PR TITLE
[bug] DateTime53 get/setTimestamp

### DIFF
--- a/Nette/Utils/DateTime53.php
+++ b/Nette/Utils/DateTime53.php
@@ -45,7 +45,7 @@ class DateTime53 extends DateTime
 
 	public function setTimestamp($timestamp)
 	{
-		return $this->__construct(gmdate('Y-m-d H:i:s', $timestamp), new DateTimeZone($this->getTimezone()->getName())); // simply getTimezone() crashes in PHP 5.2.6
+		return $this->__construct(gmdate('Y-m-d H:i:s', $timestamp + $this->getOffset()), new DateTimeZone($this->getTimezone()->getName())); // simply getTimezone() crashes in PHP 5.2.6
 	}
 
 }


### PR DESCRIPTION
DateTime53 implementuje metodu setTimestamp(), ktera chybi v php5.2.
chybu presentuje nasledujici kod:

```
  $f = '2010-01-01 12:00:00';
  $t = new DateTime53($f);
  $sf = $t->getTimestamp();
  $t->setTimestamp($sf);
  $st = $t->getTimestamp();
  var_dump($sf,$st);
```

vypise:
    int(1262343600)
    int(1262340000)

PHP5.2 pri setTimestamp(), prepocitava casy podle nastavene zony.
Pouha zmena gmdate() na date() nefunguje. Nastava problem v pripade zmeny casove zony pomozi DateTime::setTimezone();

Testy mam napsane pro PHPUnit:

```
public function testTimestamps() {
  $f = '2010-01-01 12:00:00';
  $t = new DateTime53($f);
  $s = $t->getTimestamp();

  $t->setTimestamp($s);
  $this->assertEquals($s,$t->getTimestamp());

  $s = time();
  $f = strftime('%Y-%m-%d %H:%M:%S',$s);
  $t = new DateTime53($f);

  $this->assertEquals($s,$t->getTimestamp());

  $t->setTimezone(new DateTimeZone('Indian/Comoro'));
  $t->setTimestamp($s);
  $this->assertEquals($s,$t->getTimestamp());

  $t->setTimezone(new DateTimeZone('Indian/Comoro'));
  $t->setTimestamp($s);
  $t->setTimezone(new DateTimeZone('UTC'));
  $this->assertEquals($s,$t->getTimestamp());
} 
```

Pro nette testing framework by to znamenalo prepsat velkou cast testu pro PHP5.2 (napr kvuli pouziti **DIR**)
