### PR TITLE
oprava funkce calculateSize v Image.php - vrací minimálně 1x1

### DIFF
--- a/Nette/Utils/Image.php
+++ b/Nette/Utils/Image.php
@@ -343,7 +343,7 @@ class Image extends Object
 			$newHeight = round($srcHeight * $scale);
 		}
 
-		return array((int) $newWidth, (int) $newHeight);
+		return array(max((int) $newWidth, 1), max((int) $newHeight, 1));
 	}
 
 


### PR DESCRIPTION
V Image.php funkce calculateSize vrací minimálně 1 (předejde se tím vyhozením výjimky v případě proporcionálního zmenšení extrémně neproporciálních obrázků - pokud se jeden rozměr zaokrouhlil na 0)
Viz. http://forum.nette.org/cs/6247-resize-obrazkov-prilis-neproporcionalnych-rozmerov
