### PR TITLE
Fixed wrong MethodReflection call in ClassReflection::getConstructor()

### DIFF
--- a/Nette/Reflection/ClassReflection.php
+++ b/Nette/Reflection/ClassReflection.php
@@ -134,7 +134,7 @@ class ClassReflection extends \ReflectionClass
 	 */
 	public function getConstructor()
 	{
-		return ($ref = parent::getConstructor()) ? MethodReflection::import($ref) : NULL;
+		return ($ref = parent::getConstructor()) ? MethodReflection::from($this->getName(), $ref->getName()) : NULL;
 	}
 
 


### PR DESCRIPTION
method getConstructor() is trying to initialize MethodReflection by undefined method ReflectionMethod::import() which is not defined.
