### PR TITLE
$nodeCache má být private

### DIFF
--- a/Nette/Caching/FileJournal.php
+++ b/Nette/Caching/FileJournal.php
@@ -83,7 +83,7 @@ class FileJournal extends Nette\Object implements ICacheJournal
 	private $lastModTime = NULL;
 
 	/** @var array Cache and uncommited but changed nodes */
-	public $nodeCache = array();
+	private $nodeCache = array();
 
 	/** @var array */
 	private $nodeChanged = array();


### PR DESCRIPTION
Zapomenutá chybka z doby vývoje.
