### PR TITLE
fixed TextBase::validatePattern

### DIFF
--- a/Nette/Forms/Controls/TextBase.php
+++ b/Nette/Forms/Controls/TextBase.php
@@ -213,7 +213,7 @@ abstract class TextBase extends FormControl
 	 */
 	public static function validatePattern(TextBase $control, $pattern)
 	{
-		return (bool) String::match($control->getValue(), "\x01^($pattern)$\x01u");
+		return (bool) String::match($control->getValue(), "{^($pattern)$}u");
 	}
 
 


### PR DESCRIPTION
Přepsán delimiter `\x01` na curly brackets. Přestože se `\x01` v `$pattern` nejspíš nevyskytne, nemá cenu na to spoléhat. Závorky se vždy berou jenom první a poslední, takže je to v pořádku i pokuď v `$pattern` jsou.
