### PR TITLE
Ifset macro tests block existence

### DIFF
--- a/Nette/Templates/Filters/LatteMacros.php
+++ b/Nette/Templates/Filters/LatteMacros.php
@@ -72,7 +72,7 @@ class LatteMacros extends Nette\Object
 		'elseif' => '<?php elseif (%%): ?>',
 		'else' => '<?php else: ?>',
 		'/if' => '<?php endif ?>',
-		'ifset' => '<?php if (isset(%%)): ?>',
+		'ifset' => '<?php if (isset(%:macroIfset%)): ?>',
 		'/ifset' => '<?php endif ?>',
 		'elseifset' => '<?php elseif (isset(%%)): ?>',
 		'foreach' => '<?php foreach (%:macroForeach%): ?>',
@@ -711,6 +711,22 @@ if (isset($presenter, $control) && $presenter->isAjax() && $control->isControlIn
 	public function macroForeach($content)
 	{
 		return '$iterator = $_l->its[] = new Nette\SmartCachingIterator(' . preg_replace('#(.*)\s+as\s+#i', '$1) as ', $this->formatMacroArgs($content), 1);
+	}
+
+
+
+	/**
+	 * {ifset ...}
+	 */
+	public function macroIfset($content)
+	{
+		if (strpos($content, '#') === FALSE) return $content;
+		$list = array();
+		while (($name = $this->fetchToken($content)) !== NULL) {
+			if ($name[0] === '#') $name = '$_l->blocks["' . substr($name, 1) . '"]';
+			$list[] = $name;
+		}
+		return implode(', ', $list);
 	}
 
 


### PR DESCRIPTION
Na fóru to byl docela žádaný feature request.
http://forum.nette.org/cs/6571-kontrola-zda-li-byl-v-sablone-definovam-blok

Ifset kontroluje existenci bloku:

<pre><code>{ifset #block, $promenna}
...
{/ifset}</code></pre>


Zkoušel jsem napsat i test, ale nedaří se mi assert, a to ani když pouze přidám písmeno na konec souborů. Ve složce output/ je actual a expected naprosto totožný, ale assert neprojde. Nechtělo se mi tím zabývat.
