### PR TITLE
String::firstUpper()

### DIFF
--- a/Nette/tools/String.php
+++ b/Nette/tools/String.php
@@ -230,6 +230,18 @@ final class String
 
 
 	/**
+	 * Convert first character to upper case.
+	 * @param  string  UTF-8 encoding
+	 * @return string
+	 */
+	public static function firstUpper($s)
+	{
+		return self::upper(mb_substr($s, 0, 1, 'UTF-8')) . mb_substr($s, 1, self::length($s), 'UTF-8');
+	}
+
+
+
+	/**
 	 * Capitalize string.
 	 * @param  string  UTF-8 encoding
 	 * @return string


### PR DESCRIPTION
This function is an UTF-8 variant of PHP's ucfirst().
I think it's quite useful (especially for Czech headings, etc.).
