### PR TITLE
Bug persistent params

### DIFF
--- a/Nette/Application/UI/PresenterComponentReflection.php
+++ b/Nette/Application/UI/PresenterComponentReflection.php
@@ -53,7 +53,14 @@ class PresenterComponentReflection extends Nette\Reflection\ClassType
 					'since' => $class,
 				);
 			}
-			$params = $this->getPersistentParams(get_parent_class($class)) + $params; // TODO
+			foreach ($this->getPersistentParams(get_parent_class($class)) as $name => $param) {
+				if (isset($params[$name])) {
+					$params[$name]['since'] = $param['since'];
+					continue;
+				}
+
+				$params[$name] = $param;
+			}
 		}
 		return $params;
 	}


### PR DESCRIPTION
this code producess complications

```
class A extends Presenter
{

    /** @persistent */
    public $asc = FALSE;

}

class B extends A
{

    /** @persistent */
    public $asc = TRUE;

}

class C extends A
{

}
```

It's required to maintain the origin of persistent param, but allow to overwrite it's value, which solves the patch.

The above code generates link with value as i need, but when application recieves request with empty asc param (default for B) it reads the default value from definer (A), which is obviousely wrong.

Now it reads the right value. 

Just apply the patch, it will be ok :) (possible BC break, but nobody complainted yet about this bug, so i guess nobody is using this "feature" :)
