### PR TITLE
User storage

### DIFF
--- a/Nette/Http/IUserStorage.php
+++ b/Nette/Http/IUserStorage.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (http://nette.org)
+ *
+ * Copyright (c) 2004, 2011 David Grudl (http://davidgrudl.com)
+ *
+ * For the full copyright and license information, please view
+ * the file license.txt that was distributed with this source code.
+ */
+
+namespace Nette\Web;
+
+use Nette,
+	Nette\Security\IIdentity;
+
+
+/**
+ * Interface for persistent storage for user object data.
+ *
+ * @author David Grudl, Jan Tichý
+ */
+interface IUserStorage
+{
+	/** Log-out reason {@link IUserStorage::getLogoutReason()} */
+	const MANUAL = 1,
+		INACTIVITY = 2,
+		BROWSER_CLOSED = 3;
+
+	/**
+	 * Logs in the user to the persistent storage.
+	 * @param IIdentity
+	 * @return IUserStorage Provides a fluent interface
+	 */
+	public function login(IIdentity $identity);
+
+	/**
+	 * Logs out the user from the persistent storage.
+	 * @param bool Clear the identity from persistent storage?
+	 * @return IUserStorage Provides a fluent interface
+	 */
+	public function logout($clearIdentity = FALSE);
+
+	/**
+	 * Is this user authenticated?
+	 * @return bool
+	 */
+	public function isLoggedIn();
+
+	/**
+	 * Returns current user identity, if any.
+	 * @return Nette\Security\IIdentity
+	 */
+	public function getIdentity();
+
+	/**
+	 * Changes namespace; allows more users to share the persistent storage.
+	 * @param string
+	 * @return IUserStorage Provides a fluent interface
+	 */
+	public function setNamespace($namespace);
+
+	/**
+	 * Returns current namespace of the persistent storage.
+	 * @return string
+	 */
+	public function getNamespace();
+
+	/**
+	 * Enables log out from the persistent storage after inactivity.
+	 * @param string|int|DateTime number of seconds or timestamp
+	 * @param bool Log out when the browser is closed?
+	 * @param bool Clear the identity from persistent storage?
+	 * @return IUserStorage Provides a fluent interface
+	 */
+	public function setExpiration($time, $whenBrowserIsClosed = TRUE, $clearIdentity = FALSE);
+
+	/**
+	 * Why was user logged out?
+	 * @return int
+	 */
+	public function getLogoutReason();
+}

--- a/Nette/Http/UserStorage.php
+++ b/Nette/Http/UserStorage.php
@@ -1,0 +1,230 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (http://nette.org)
+ *
+ * Copyright (c) 2004, 2011 David Grudl (http://davidgrudl.com)
+ *
+ * For the full copyright and license information, please view
+ * the file license.txt that was distributed with this source code.
+ */
+
+namespace Nette\Web;
+
+use Nette,
+	Nette\Security\IIdentity;
+
+
+/**
+ * Session storage for user object.
+ *
+ * @author David Grudl, Jan Tichý
+ */
+class UserStorage extends Nette\Object implements IUserStorage
+{
+	/** @var string */
+	private $namespace = '';
+
+	/** @var Session */
+	private $sessionHandler;
+
+	/** @var SessionNamespace */
+	private $sessionNamespace;
+
+	/**
+	 * Inject session handler. No more Environment.
+	 * @param Nette\Web\Session
+	 */
+	public function  __construct(Session $sessionHandler)
+	{
+		$this->sessionHandler = $sessionHandler;
+	}
+
+	/**
+	 * Logs in the user to the current session.
+	 * @param IIdentity
+	 * @return UserStorage Provides a fluent interface
+	 */
+	public function login(IIdentity $identity)
+	{
+		$this->setIdentity($identity);
+		$this->setAuthenticated(TRUE);
+		return $this;
+	}
+
+	/**
+	 * Logs out the user from the current session.
+	 * @param bool Clear the identity from persistent storage?
+	 * @return UserStorage Provides a fluent interface
+	 */
+	public function logout($clearIdentity = FALSE)
+	{
+		$this->setAuthenticated(FALSE);
+		if ($clearIdentity) {
+			$this->setIdentity(NULL);
+		}
+	}
+	
+	/**
+	 * Is this user authenticated?
+	 * @return bool
+	 */
+	public function isLoggedIn()
+	{
+		$session = $this->getSessionNamespace(FALSE);
+		return $session && $session->authenticated;
+	}
+
+	/**
+	 * Returns current user identity, if any.
+	 * @return Nette\Security\IIdentity
+	 */
+	public function getIdentity()
+	{
+		$session = $this->getSessionNamespace(FALSE);
+		return $session ? $session->identity : NULL;
+	}
+
+	/**
+	 * Changes namespace; allows more users to share a session.
+	 * @param string
+	 * @return UserStorage Provides a fluent interface
+	 */
+	public function setNamespace($namespace)
+	{
+		if ($this->namespace !== $namespace) {
+			$this->namespace = (string) $namespace;
+			$this->sessionNamespace = NULL;
+		}
+		return $this;
+	}
+
+	/**
+	 * Returns current namespace.
+	 * @return string
+	 */
+	public function getNamespace()
+	{
+		return $this->namespace;
+	}
+
+	/**
+	 * Enables log out after inactivity.
+	 * @param string|int|DateTime Number of seconds or timestamp
+	 * @param bool Log out when the browser is closed?
+	 * @param bool Clear the identity from persistent storage?
+	 * @return UserStorage Provides a fluent interface
+	 */
+	public function setExpiration($time, $whenBrowserIsClosed = TRUE, $clearIdentity = FALSE)
+	{
+		$session = $this->getSessionNamespace(TRUE);
+		if ($time) {
+			$time = Nette\Tools::createDateTime($time)->format('U');
+			$session->expireTime = $time;
+			$session->expireDelta = $time - time();
+
+		} else {
+			unset($session->expireTime, $session->expireDelta);
+		}
+
+		$session->expireIdentity = (bool) $clearIdentity;
+		$session->expireBrowser = (bool) $whenBrowserIsClosed;
+		$session->browserCheck = TRUE;
+		$session->setExpiration(0, 'browserCheck');
+		return $this;
+	}
+
+	/**
+	 * Why was user logged out?
+	 * @return int
+	 */
+	public function getLogoutReason()
+	{
+		$session = $this->getSessionNamespace(FALSE);
+		return $session ? $session->reason : NULL;
+	}
+
+	/**
+	 * Returns and initializes $this->session.
+	 * @return SessionNamespace
+	 */
+	protected function getSessionNamespace($need)
+	{
+		if ($this->sessionNamespace !== NULL) {
+			return $this->sessionNamespace;
+		}
+
+		if (!$need && !$this->sessionHandler->exists()) {
+			return NULL;
+		}
+
+		$this->sessionNamespace = $session = $this->sessionHandler->getNamespace('Nette.Web.User/' . $this->namespace);
+
+		if (!$session->identity instanceof IIdentity || !is_bool($session->authenticated)) {
+			$session->remove();
+		}
+
+		if ($session->authenticated && $session->expireBrowser && !$session->browserCheck) { // check if browser was closed?
+			$session->reason = self::BROWSER_CLOSED;
+			$session->authenticated = FALSE;
+			$this->onLoggedOut($this);
+			if ($session->expireIdentity) {
+				unset($session->identity);
+			}
+		}
+
+		if ($session->authenticated && $session->expireDelta > 0) { // check time expiration
+			if ($session->expireTime < time()) {
+				$session->reason = self::INACTIVITY;
+				$session->authenticated = FALSE;
+				$this->onLoggedOut($this);
+				if ($session->expireIdentity) {
+					unset($session->identity);
+				}
+			}
+			$session->expireTime = time() + $session->expireDelta; // sliding expiration
+		}
+
+		if (!$session->authenticated) {
+			unset($session->expireTime, $session->expireDelta, $session->expireIdentity,
+				$session->expireBrowser, $session->browserCheck, $session->authTime);
+		}
+
+		return $this->sessionNamespace;
+	}
+
+	/**
+	 * Sets the authenticated status of this user.
+	 * @param bool Flag indicating the authenticated status of user
+	 * @return UserStorage Provides a fluent interface
+	 */
+	protected function setAuthenticated($state)
+	{
+		$session = $this->getSessionNamespace(TRUE);
+		$session->authenticated = (bool) $state;
+
+		// Session Fixation defence
+		$this->sessionHandler->regenerateId();
+
+		if ($state) {
+			$session->reason = NULL;
+			$session->authTime = time(); // informative value
+
+		} else {
+			$session->reason = self::MANUAL;
+			$session->authTime = NULL;
+		}
+		return $this;
+	}
+
+	/**
+	 * Sets the user identity.
+	 * @param IIdentity
+	 * @return UserStorage Provides a fluent interface
+	 */
+	protected function setIdentity(IIdentity $identity = NULL)
+	{
+		$this->getSessionNamespace(TRUE)->identity = $identity;
+		return $this;
+	}
+}


### PR DESCRIPTION
Ahoj, posílám návrh na změnu ve třídě User a oddělení části její funkčnosti do nové třídy UserStorage (deklarované novým rozhraním IUserStorage).

Důvod pro změnu začnu konkrétním případem z naší praxe. Nettí třída User nám z různých důvodů dlouhodobě příliš nevyhovuje, takže jsme si napsali vlastní. Nicméně i do naší třídy musíme znovu psát či vlastně natvrdo kopírovat podstatnou část Nette User. Konkrétně se jedná právě o všechny věci kolem ukládání dat do sessions apod. Dává tedy myslím velký smysl oddělit tuto část do samostatné třídy UserStorage a v samotném User už ji jen na pozadí volat a využívat.

Když už jsem to dělal, tak jsem to pojal trochu víc zeširoka a víc obecně. Sessions jsou de facto jen jedním z možných (i když v praxi nakonec asi jediným využívaným, ale to není důležité) uložišť, kde lze data uchovávat. Takže jsem definoval obecný interface IUserStorage pro obecné uchovávání dat o aktuálním přihlášení. Výše zmíněný UserStorage už je pak jen jeho konkrétní implementací využívající právě sessions.

V zájmu zpětné kompatibility jsem pak samotnou třídu User upravil tak, že se vůbec nijak nezměnilo její rozhraní. Což je sice trochu na škodu eleganci celé věci, ale zase to nerozbourá žádné dosavadní aplikace.

Kdyby ale byl zájem to udělat čistěji i za cenu nabourání zpětné kompatibiliy, tak tady jsou další možná todos, co by šlo s User udělat:
- Místo tvrdého instancování UserStorage v metodě User::getStorage() by bylo vhodnější injectovat konkrétní UserStorage přes konstruktor nebo přes ServiceLocator. 
- Obdobně by pak bylo vhodné z metody User::getStorage() vykopat ten Environment a ideálně ho už dostat injectovaný přímo do UserStorage.
- Symbolické konstanty pro důvody logoutu patří správně do UserStorage, takže je pak otázka, zda je takhle přepisovat a zrcadlit i do User, nebo zda je z User zrušit a nechat je jen v UserStorage.
- Stejně tak už by v IUser/User vůbec nemusela být getNamespace/setNamespace - to je spíš otázka konfigurace daného IUserStorage, spíš než konfigurace konkrétního Usera. Ale to je tak půl na půl.
- Otázkou pak je, zda pak ještě IUserStorage patří do Web/Http, když je od web/http/cookies/sessions vlastně úplně abstrahovaný. Totéž pak platí i pro User a IUser jako takového - pokud by v něm byl IUserStorage vyměnitelný, tak de facto už taky do Web/Http nepatří. Jediné, co sem nakonec patří, je pak vlastně jen ta konkrétní implementace UserStorage.
