### PR TITLE
Fix: debug panel exceptions

### DIFF
--- a/Nette/Diagnostics/DebugHelpers.php
+++ b/Nette/Diagnostics/DebugHelpers.php
@@ -49,11 +49,20 @@ final class DebugHelpers
 	public static function renderDebugBar($panels)
 	{
 		foreach ($panels as $key => $panel) {
-			$panels[$key] = array(
-				'id' => preg_replace('#[^a-z0-9]+#i', '-', $panel->getId()),
-				'tab' => $tab = (string) $panel->getTab(),
-				'panel' => $tab ? (string) $panel->getPanel() : NULL,
-			);
+			try {
+				$panels[$key] = array(
+					'id' => preg_replace('#[^a-z0-9]+#i', '-', $panel->getId()),
+					'tab' => $tab = (string) $panel->getTab(),
+					'panel' => $tab ? (string) $panel->getPanel() : NULL,
+				);
+			}
+			catch(\Exception $e) {
+				$panels[$key] = array(
+					'id' => "error-$key",
+					'tab' => "Error: $key",
+					'panel' => $e->getMessage(),
+				);
+			}
 		}
 		require __DIR__ . '/templates/bar.phtml';
 	}


### PR DESCRIPTION
Debug bar crashes if there is exception in one of it's panels, which is quiet ironic as it should show error on page
