### PR TITLE
Refactor form container

### DIFF
--- a/Nette/Forms/FormContainer.php
+++ b/Nette/Forms/FormContainer.php
@@ -74,28 +74,26 @@ class FormContainer extends Nette\ComponentContainer implements \ArrayAccess
 			throw new \InvalidArgumentException("First parameter must be an array, " . gettype($values) ." given.");
 		}
 
-		$cursor = & $values;
-		$iterator = $this->getComponents(TRUE);
+		$iterator = $this->getComponents(FALSE);
 		foreach ($iterator as $name => $control) {
-			$sub = $iterator->getSubIterator();
-			if (!isset($sub->cursor)) {
-				$sub->cursor = & $cursor;
-			}
 			if ($control instanceof IFormControl) {
-				if ((is_array($sub->cursor) || $sub->cursor instanceof \ArrayAccess) && array_key_exists($name, $sub->cursor)) {
-					$control->setValue($sub->cursor[$name]);
+				if (array_key_exists($name, $values)) {
+					$control->setValue($values[$name]);
 
 				} elseif ($erase) {
 					$control->setValue(NULL);
 				}
 			}
 			if ($control instanceof FormContainer) {
-				if ((is_array($sub->cursor) || $sub->cursor instanceof \ArrayAccess) && isset($sub->cursor[$name])) {
-					$cursor = & $sub->cursor[$name];
-				} else {
-					unset($cursor);
-					$cursor = NULL;
+				if (isset($values[$name])) {
+					$control->setValues($values[$name], $erase);
+
+				} elseif ($erase) {
+					$control->setValues(array(), $erase);
 				}
+			}
+			elseif ($control instanceof \Nette\ComponentContainer) { // Take out all components from non-named container
+				foreach($control->getComponents() as $name2 => $component) $iterator[$name2] = $component;
 			}
 		}
 		return $this;
@@ -110,18 +108,16 @@ class FormContainer extends Nette\ComponentContainer implements \ArrayAccess
 	public function getValues()
 	{
 		$values = new Nette\ArrayHash;
-		$cursor = $values;
-		$iterator = $this->getComponents(TRUE);
+		$iterator = $this->getComponents(FALSE);
 		foreach ($iterator as $name => $control) {
-			$sub = $iterator->getSubIterator();
-			if (!isset($sub->cursor)) {
-				$sub->cursor = $cursor;
-			}
 			if ($control instanceof IFormControl && !$control->isDisabled() && !$control instanceof ISubmitterControl) {
-				$sub->cursor->$name = $control->getValue();
+				$values->$name = $control->getValue();
 			}
 			if ($control instanceof FormContainer) {
-				$cursor = $sub->cursor->$name = new Nette\ArrayHash;
+				$values->$name = $control->getValues();
+			}
+			elseif ($control instanceof \Nette\ComponentContainer) { // Take out all components from non-named container
+				foreach($control->getComponents() as $name2 => $component) $iterator[$name2] = $component;
 			}
 		}
 		return $values;


### PR DESCRIPTION
Refactored Nette\Forms\FormContainer::getValues and ::setValues to use recursion instead of ugly recursive iterators. This code is much more straightforward in what it should do plus it allows extension (see below). Plus, all tests pass on it (so it shouldn't break anything)

See discussion on http://forum.nette.org/cs/6964-prilisna-slozitost-formcontainer-setvalues-getvalues

It also allows possible extension on your specific named containers: you can implement a class extending FormContainer and by overriding setValue + getValue methods, you can do absolutely whatever you want (like creating dynamic number of elements etc.) Serialization and deserialization is completely in your hands. This also goes very well with https://github.com/Foowie/DynamicFormContainer addon which when impelemting setValue + getValue can work much better than it's working now (pull request for that addon will be provided soon)
