### PR TITLE
Test scripts: no numbers in failure overview

### DIFF
--- a/tests/NetteTest/RunTests.php
+++ b/tests/NetteTest/RunTests.php
@@ -18,6 +18,7 @@ Options:
 	-d key=val  Define INI entry 'key' with value 'val'.
 	-l <path>   Specify path to shared library files (LD_LIBRARY_PATH)
 	-s          Show information about skipped tests
+	-n          Do not show numbers in failure overview (useful for comparing different versions)
 
 <?php
 }

--- a/tests/NetteTest/TestRunner.php
+++ b/tests/NetteTest/TestRunner.php
@@ -37,6 +37,9 @@ class TestRunner
 
 	/** @var bool  display skipped tests information? */
 	public $displaySkipped = FALSE;
+	
+	/** @var bool  display numbers in failure list */
+	public $displayFailureNumbers = TRUE;
 
 
 
@@ -101,7 +104,7 @@ class TestRunner
 			echo "\n\nFailures:\n";
 			foreach ($failed as $i => $item) {
 				list($name, $file, $message) = $item;
-				echo "\n", ($i + 1), ") $name\n   $message\n   $file\n";
+				echo "\n", ($this->displayFailureNumbers ? $i + 1 : ''), ") $name\n   $message\n   $file\n";
 			}
 			echo "\nFAILURES! ($count tests, $failedCount failures, $skippedCount skipped)\n";
 			return FALSE;
@@ -150,6 +153,9 @@ class TestRunner
 					break;
 				case 's':
 					$this->displaySkipped = TRUE;
+					break;
+				case 'n':
+					$this->displayFailureNumbers = FALSE;
 					break;
 				default:
 					throw new Exception("Unknown option -$arg[1].");


### PR DESCRIPTION
Added new option for tests/run-tests.sh, which disables numbering in failure overview.

This can be useful when testing your patches against mainstream. You can git-checkout origin/master and run tests with output to temp file, then checkout your updated version and run test to another temp file. As there are lot's failures at the moment in dev version of Nette, it's not so easy to find whether you brought any other failures and which ones if so. When you suppress numbers in failure overview, outputs become easily comparable by diff for example. Thus, you can see immediately what failures are happening because of your code.

Example:
    git checkout origin/master 
    ./tests/run-tests.sh tests/Forms/ | tee /tmp/tests_master
    git checkout refactor_FormContainer 
    ./tests/run-tests.sh tests/Forms/ | tee /tmp/tests_feature
    git diff /tmp/tests_master /tmp/tests_feature && echo 'Everything seems to be OK!'
