### PR TITLE
Debug is not final and Debug::log returns exception filename

### DIFF
--- a/Nette/Diagnostics/Debug.php
+++ b/Nette/Diagnostics/Debug.php
@@ -330,6 +330,8 @@ class Debug
 			ob_end_clean();
 			fclose($logHandle);
 		}
+		
+		return $exceptionFilename;
 	}
 
 


### PR DESCRIPTION
Na základě diskuse z https://github.com/nette/nette/commit/da7631850105dd849ba10bf14532fb3d28f5c690 přidávám pull request na podporu této funkcionality, zároveň jsem odstranil od této třídy final.
