### PR TITLE
Veľkonočná nádielka

### DIFF
--- a/tests/Nette/Caching/FileStorage.exceptions.phpt
+++ b/tests/Nette/Caching/FileStorage.exceptions.phpt
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Test: Nette\Caching\Storages\FileStorage exception situations.
+ *
+ * @author     Matej Kravjar
+ * @package    Nette\Caching
+ * @subpackage UnitTests
+ */
+
+use Nette\Caching\Cache,
+	Nette\Caching\Storages\FileStorage;
+
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+
+// purge temporary directory
+TestHelpers::purge(TEMP_DIR);
+// do not create cache directory
+
+
+
+try {
+	new FileStorage(TEMP_DIR . '/cache');
+	Assert::fail('Expected exception');
+} catch (Exception $e) {
+	Assert::exception('Nette\DirectoryNotFoundException', "Directory '%a%' not found.", $e);
+}
+
+
+
+// create cache directory
+mkdir(TEMP_DIR . '/cache');
+
+
+
+try {
+	$storage = new FileStorage(TEMP_DIR . '/cache');
+	$storage->write('a', 'b', array(Cache::TAGS => 'c'));
+	Assert::fail('Expected exception');
+} catch (Exception $e) {
+	Assert::exception('Nette\InvalidStateException', 'CacheJournal has not been provided.', $e);
+}


### PR DESCRIPTION
Trochu som testoval, u mňa doma zlyhávajú tie isté testy ako Vrtakovi (len v inom poradí).
1. ViewCoverage.php
   fix iterátora aby preskakoval . a .. (podobný fix ako pred časom niekde inde)
2. tests Mail (-4 failures):
   a) Keďže sa detektor MIME na neobrázkoch správa rôzne, najistejšie mi pripadá nastaviť mu správny typ natvrdo.
   b) nemali by byť prílohy linkované celou cestou?
   c) je nutné reálne vytvárať súbor žluťoučký.zip, nestačí len použiť názov súboru? Na Linuxe mi ho potom nevie otvoriť a zlyhá...
3. Latte\Parser
   výraz `[\r\n]{0,2}` matchne max jeden windowsový ale max dva linuxové riadky --> robí to rozdiely v templejtoch. problémy robí aj n:foreach (na ten fix nemám)
4. osobne ma štve dirty tree kvôli tmp adresáru Cachingu a všetkým možným outputom, preto som dal keši tmp+gitignore, takisto spravil gitignore na outputy a coverage.
5. Debugger.E_ERROR.html.phpt generuje output do Nette adresára (pretože zle z tracu identifikuje súbor s testom). Vyskúšal som zlepšenie a zatiaľ zdá sa funguje. Experimental...
6. Veľmi mi pomáha ak si viem jednoducho pozrieť na čom zlyhal niektorý z testov -- povezme "ukáž na čom zlyhal test č. 2".
   
   `tests/run-tests.sh -dlog tests/diff.log tests/Nette`
   `tests/diff-viewer.sh 2 # zobrazí diff druhého zlyhaného testu`
   
   Je to  skôr na inšpiráciu, nejde mi primárne o to, aby to bolo v distribúcii...
7. php.ini v repe ma trochu štve. keďže php automaticky načítava php.ini v aktuálnom adresári (wtf), tak nemôžem púšťať testy z tests/ ale musím odinakiaľ. Je to trochu nepohodlné...
