### PR TITLE
Diagnostics bar no longer creates empty space at the end of page

### DIFF
--- a/Nette/Diagnostics/templates/bar.phtml
+++ b/Nette/Diagnostics/templates/bar.phtml
@@ -31,6 +31,7 @@ use Nette;
 	/* common styles */
 	#nette-debug {
 		display: none;
+		position: fixed;
 	}
 
 	body#nette-debug {


### PR DESCRIPTION
Současný kaskády panelu vytvoří na konci stránky prázdné místo.

Špatně se kvůli tomu ladí styly webu, když je tam kontejner na 100% height.

Původně:
![original](http://i51.tinypic.com/2uivf9g.png)

Opravené:
![fixed](http://i53.tinypic.com/f1dx5j.png)

Přestože by to mělo být v pohodě, pro jistotu jsem to otestoval jsem to ve všech současných prohlížečích a chová se to správně.
