### PR TITLE
Nette\Caching: add Cache::has($key)

### DIFF
--- a/Nette/Caching/Cache.php
+++ b/Nette/Caching/Cache.php
@@ -124,6 +124,18 @@ class Cache extends Nette\Object implements \ArrayAccess
 
 
 	/**
+	 * Exists item in cache?
+	 * @param  mixed key
+	 * @return bool
+	 */
+	public function has($key)
+	{
+		return $this->load($key) !== NULL;
+	}
+
+
+
+	/**
 	 * Writes item into the cache.
 	 * Dependencies are:
 	 * - Cache::PRIORITY => (int) priority
@@ -288,7 +300,7 @@ class Cache extends Nette\Object implements \ArrayAccess
 	 */
 	public function offsetExists($key)
 	{
-		return $this->load($key) !== NULL;
+		return $this->has($key);
 	}
 
 


### PR DESCRIPTION
Pokud používám `$cache->save($key, ...)`,  `$cache->load($key)` a `$cache->delete($key)` tak je trochu WTF používat `isset($cache[$key])`
