### PR TITLE
Application - added onPresenter() callback

### DIFF
--- a/Nette/Application/Application.php
+++ b/Nette/Application/Application.php
@@ -40,6 +40,9 @@ class Application extends Nette\Object
 	/** @var array of function(Application $sender, Request $request); Occurs when a new request is ready for dispatch */
 	public $onRequest;
 
+	/** @var array of function(Application $sender, Presenter $request); Occurs when a presenter is ready for run */
+	public $onPresenter;
+
 	/** @var array of function(Application $sender, IResponse $response); Occurs when a new response is received */
 	public $onResponse;
 
@@ -136,6 +139,8 @@ class Application extends Nette\Object
 				$this->getPresenterFactory()->getPresenterClass($presenterName);
 				$request->setPresenterName($presenterName);
 				$request->freeze();
+
+				$this->onPresenter($this, $this->presenter);
 
 				// Execute presenter
 				$response = $this->presenter->run($request);


### PR DESCRIPTION
Umožní modifikace či přístup k presenteru z "vnějšku" ještě před jeho spuštěním. Vhodné pro snadnější tvorbu některých typů panelů a obecně větší volnost a ohybatelnost, stejně jako u ostatních "onSomething" callbacků Nette\Application.

Viz také http://forum.nette.org/cs/6759-nove-formulare-a-dotaznik?p=2#p55467
