### PR TITLE
User: allow exchange of authenticator and authorizator

### DIFF
--- a/Nette/Http/User.php
+++ b/Nette/Http/User.php
@@ -151,6 +151,7 @@ class User extends Nette\Object implements IUser
 	 */
 	public function setAuthenticationHandler(IAuthenticator $handler)
 	{
+		$this->context->removeService('authenticator');
 		$this->context->authenticator = $handler;
 		return $this;
 	}
@@ -385,6 +386,7 @@ class User extends Nette\Object implements IUser
 	 */
 	public function setAuthorizationHandler(IAuthorizator $handler)
 	{
+		$this->context->removeService('authorizator');
 		$this->context->authorizator = $handler;
 		return $this;
 	}


### PR DESCRIPTION
Nefunguje opakované zavolání:

```
$user->setAuthenticationHandler(new AdminAuthenticator);
```

Což v předchozích verzích Nette fungovalo.
