### PR TITLE
Framework::$iAmUsingBadHost respected in Configurator

### DIFF
--- a/Nette/common/Configurator.php
+++ b/Nette/common/Configurator.php
@@ -272,7 +272,7 @@ class Configurator extends Object
 
 		if (function_exists('ini_set')) {
 			return $this->generateCode('ini_set', $name, $value);
-		} elseif (ini_get($name) != $value) { // intentionally ==
+		} elseif (ini_get($name) != $value && !Framework::$iAmUsingBadHost) { // intentionally ==
 			throw new Nette\NotSupportedException('Required function ini_set() is disabled.');
 		}
 	}


### PR DESCRIPTION
Required for hostings with `ini_set` disabled (oh my).
