### PR TITLE
Forms: fixed setMethod always throwing exception [Closes #236]

### DIFF
--- a/Nette/Forms/Form.php
+++ b/Nette/Forms/Form.php
@@ -194,7 +194,7 @@ class Form extends Container
 	 */
 	public function setMethod($method)
 	{
-		if ($this->httpData !== NULL) {
+		if ($this->httpData) {
 			throw new Nette\InvalidStateException(__METHOD__ . '() must be called until the form is empty.');
 		}
 		$this->element->method = strtolower($method);


### PR DESCRIPTION
Nějaký commit asi z Form::$httpData udělala array, takže místo testování na NULL je tam jenom existence obsahu.

Closes https://github.com/nette/nette/issues/236
