### PR TITLE
Improved debugger output to console

### DIFF
--- a/Nette/Diagnostics/Debugger.php
+++ b/Nette/Diagnostics/Debugger.php
@@ -416,7 +416,10 @@ final class Debugger
 
 			} else {
 				if (self::$consoleMode) { // dump to console
-					echo "$exception\n";
+					if (ob_get_level()) {
+						ob_end_clean();
+					}
+					echo "\n$exception\n";
 
 				} elseif ($htmlMode) { // dump to browser
 					self::$blueScreen->render($exception);


### PR DESCRIPTION
- Pokud došlo k výjimce uvnitř ob_start, tak se do konzole vypisoval aktuální obsah bufferu.
- V konzoli se může zrovna vykreslovat třeba progressbar, proto je dobré před vypsáním chyby odsadit jednu řádku.
