### PR TITLE
Moved debugger initialization to loader.php

### DIFF
--- a/Nette/Diagnostics/Debugger.php
+++ b/Nette/Diagnostics/Debugger.php
@@ -15,12 +15,6 @@ use Nette;
 
 
 
-require_once __DIR__ . '/Helpers.php';
-require_once __DIR__ . '/../Utils/Html.php';
-require_once __DIR__ . '/../Utils/Strings.php';
-
-
-
 /**
  * Debugger: displays and logs errors.
  *
@@ -662,7 +656,3 @@ final class Debugger
 	}
 
 }
-
-
-
-Debugger::_init();

--- a/Nette/loader.php
+++ b/Nette/loader.php
@@ -52,6 +52,8 @@ require_once __DIR__ . '/Loaders/NetteLoader.php';
 
 Nette\Loaders\NetteLoader::getInstance()->register();
 
+Nette\Diagnostics\Debugger::_init();
+
 Nette\Utils\SafeStream::register();
 
 


### PR DESCRIPTION
Ti, co načítají framework doporučovaným způsobem přes loader.php, nepoznají rozdíl, ale změna ulehčí práci těm, co si chtějí udělat vlastní minifikovanou verzi, vytvořit nette.phar nebo prostě používat Nette trochu jinak.

Vzhledem k tomu, že `Debugger::_init()` je označena jako internal, tak by se mi víc líbilo, kdyby se `_init()` volal hned na začátku `enable()`, ale to momentálně nejde, protože třeba volání `log()` by pak spadlo, že `self::$logger` je null.
