### PR TITLE
Strings::normalize: remove ASCII DEL character

### DIFF
--- a/Nette/Utils/Strings.php
+++ b/Nette/Utils/Strings.php
@@ -112,7 +112,7 @@ class Strings
 		$s = strtr($s, "\r", "\n"); // Mac
 
 		// remove control characters; leave \t + \n
-		$s = preg_replace('#[\x00-\x08\x0B-\x1F]+#', '', $s);
+		$s = preg_replace('#[\x00-\x08\x0B-\x1F\x7F]+#', '', $s);
 
 		// right trim
 		$s = preg_replace("#[\t ]+$#m", '', $s);

--- a/tests/Nette/Utils/Strings.normalize().phpt
+++ b/tests/Nette/Utils/Strings.normalize().phpt
@@ -17,3 +17,8 @@ require __DIR__ . '/../bootstrap.php';
 
 
 Assert::same( "Hello\n  World",  Strings::normalize("\r\nHello  \r  World \n\n") );
+
+Assert::same( "Hello  World",  Strings::normalize("Hello \x00 World") );
+Assert::same( "Hello  World",  Strings::normalize("Hello \x0B World") );
+Assert::same( "Hello  World",  Strings::normalize("Hello \x1F World") );
+Assert::same( "Hello  World",  Strings::normalize("Hello \x7F World") );


### PR DESCRIPTION
Odstraňuje ze stringu i ASCII znak DEL, který tam také nemá co dělat.
