### PR TITLE
fixed clickable dump not to cover multiple lines with links

### DIFF
--- a/Nette/Diagnostics/Helpers.php
+++ b/Nette/Diagnostics/Helpers.php
@@ -181,12 +181,12 @@ final class Helpers
 	public static function clickableDump($dump)
 	{
 		return '<pre class="nette-dump">' . preg_replace_callback(
-			'#^( *)((?>[^(]{1,200}))\((\d+)\) <code>#m',
+			'#^( *)((?>[^(\r\n]{1,200}))\((\d+)\) <code>#m',
 			function ($m) {
 				return "$m[1]<a href='#' rel='next'>$m[2]($m[3]) "
 					. (trim($m[1]) || $m[3] < 7
-					? '<abbr>&#x25bc;</abbr> </a><code>'
-					: '<abbr>&#x25ba;</abbr> </a><code class="nette-collapsed">');
+					? '<abbr>&#x25bc;</abbr></a> <code>'
+					: '<abbr>&#x25ba;</abbr></a> <code class="nette-collapsed">');
 			},
 			self::htmlDump($dump)
 		) . '</pre>';


### PR DESCRIPTION
bug: clickable dump creates clickable links which spread across more lines of code
