### PR TITLE
RadioList::getControl() may returns incorrect item

### DIFF
--- a/Nette/Forms/Controls/RadioList.php
+++ b/Nette/Forms/Controls/RadioList.php
@@ -147,7 +147,7 @@ class RadioList extends BaseControl
 
 		foreach ($this->items as $k => $val) {
 			$counter++;
-			if ($key !== NULL && $key != $k) { // intentionally ==
+			if ($key !== NULL && (string) $key !== (string) $k) {
 				continue;
 			}
 


### PR DESCRIPTION
This code returns Html object for item with key: 1, but expected is: 1a:

> $form->addRadioList('test')->setItems(array('1' => '1', '1a' => '1a'))->getControl('1a')
