### PR TITLE
Strings::normalize: remove and substitute C1 control characters

### DIFF
--- a/Nette/Utils/Strings.php
+++ b/Nette/Utils/Strings.php
@@ -102,6 +102,7 @@ class Strings
 
 	/**
 	 * Removes special controls characters and normalizes line endings and spaces.
+	 * @see http://en.wikipedia.org/wiki/C0_and_C1_control_codes
 	 * @param  string  UTF-8 encoding or 8-bit
 	 * @return string
 	 */
@@ -113,6 +114,16 @@ class Strings
 
 		// remove control characters; leave \t + \n
 		$s = preg_replace('#[\x00-\x08\x0B-\x1F]+#', '', $s);
+
+		for ($i = 0x80; $i <= 0x83; $i++) {
+			$s = str_replace("\xC2" . chr($i), ' ', $s);
+		}
+
+		$s = str_replace("\xC2" . chr(0x84), "\n", $s);
+
+		for ($i = 0x86; $i <= 0xA0; $i++) {
+			$s = str_replace("\xC2" . chr($i), '', $s);
+		}
 
 		// right trim
 		$s = preg_replace("#[\t ]+$#m", '', $s);

--- a/tests/Nette/Utils/Strings.normalize().phpt
+++ b/tests/Nette/Utils/Strings.normalize().phpt
@@ -17,3 +17,9 @@ require __DIR__ . '/../bootstrap.php';
 
 
 Assert::same( "Hello\n  World",  Strings::normalize("\r\nHello  \r  World \n\n") );
+
+Assert::same( "HelloWorld",  Strings::normalize("Hello\xC2\xA0World") );
+
+Assert::same( "Hello World",  Strings::normalize("Hello\xC2\x83World") );
+
+Assert::same( "Hello\nWorld",  Strings::normalize("Hello\xC2\x84World") );


### PR DESCRIPTION
Odstranění C1 řídících znaků.

http://en.wikipedia.org/wiki/C0_and_C1_control_codes
http://www.unicode.org/charts/PDF/U0080.pdf
