### PR TITLE
Better production/development mode detection while running from CLI

### DIFF
--- a/Nette/common/Configurator.php
+++ b/Nette/common/Configurator.php
@@ -226,7 +226,7 @@ class Configurator extends Object
 	{
 		$addrs = array();
 		if (PHP_SAPI === 'cli') {
-			$addrs[] = getHostByName(getHostName());
+			$addrs[] = getHostByName(php_uname('n')); 
 		}
 		else {
 			if (!isset($_SERVER['SERVER_ADDR']) && !isset($_SERVER['LOCAL_ADDR'])) {


### PR DESCRIPTION
Configurator ignores development mode when running from CLI and sets always mode to production. That causes problems but mostly with config.neon parsing when running in development mode as wrong section is passed to loadConfig().

I suppose this relates to fact that it's not that trivial to detect IP address in CLI. I suppose getHostByName(getHostName()) works quite well to be used in detectProductionMode().
