### PR TITLE
Diagnostics: RoutingPanel doesn't take in account ONE_WAY routes

### DIFF
--- a/Nette/Application/Diagnostics/RoutingPanel.php
+++ b/Nette/Application/Diagnostics/RoutingPanel.php
@@ -106,7 +106,7 @@ class RoutingPanel extends Nette\Object implements Nette\Diagnostics\IBarPanel
 
 		$request = $router->match($this->httpRequest);
 		$matched = $request === NULL ? 'no' : 'may';
-		if ($request !== NULL && empty($this->request)) {
+		if ($request !== NULL && empty($this->request) && (!$router instanceof Routers\Route || $router->getTargetPresenter() !== FALSE)) {
 			$this->request = $request;
 			$matched = 'yes';
 		}


### PR DESCRIPTION
ONE_WAY routes can't be matched as current, RoutingPanel is ignoring this fact.
