### PR TITLE
Politely extensible Nette\Http\User

### DIFF
--- a/Nette/Http/User.php
+++ b/Nette/Http/User.php
@@ -67,6 +67,16 @@ class User extends Nette\Object implements IUser
 
 
 
+	/**
+	 * @return Nette\DI\IContainer
+	 */
+	protected function getContext()
+	{
+		return $this->context;
+	}
+
+
+
 	/********************* Authentication ****************d*g**/
 
 


### PR DESCRIPTION
Make Nette\Http\User easily extensible. Nowadays the whole class has to be duplicated, just to be able to change one method.
