### PR TITLE
Translate Form errors

### DIFF
--- a/Nette/Forms/Rendering/DefaultFormRenderer.php
+++ b/Nette/Forms/Rendering/DefaultFormRenderer.php
@@ -256,12 +256,13 @@ class DefaultFormRenderer extends Nette\Object implements Nette\Forms\IFormRende
 			$ul = $this->getWrapper('error container');
 			$li = $this->getWrapper('error item');
 
+			$translator = $this->form->getTranslator();
 			foreach ($errors as $error) {
 				$item = clone $li;
 				if ($error instanceof Html) {
 					$item->add($error);
 				} else {
-					$item->setText($error);
+					$item->setText($translator !== NULL ? $translator->translate($error) : $error);
 				}
 				$ul->add($item);
 			}


### PR DESCRIPTION
Error messages in forms added by `Form::addError()` are not translated even if `ITranslator` is present in the form.
