### PR TITLE
Debugging: debugging of overriding and extending Nette

### DIFF
--- a/Nette/loader.php
+++ b/Nette/loader.php
@@ -53,6 +53,8 @@ require_once __DIR__ . '/Loaders/NetteLoader.php';
 
 Nette\Loaders\NetteLoader::getInstance()->register();
 
+require_once __DIR__ . '/Diagnostics/Helpers.php';
+require_once __DIR__ . '/Utils/Html.php';
 Nette\Diagnostics\Debugger::_init();
 
 Nette\Utils\SafeStream::register();


### PR DESCRIPTION
Občas se stane, při rozšiřování nebo přepisování služeb, které se spouští jako první, třeba robotLoader, nebo Application, že Nette nevyhodí správnou výjimku, ale umře na "class Nette\Debugging\Helpers not found".

Je to proto, že třídy které využívá Debugger ještě nebyly načteny a ani není možné je načíst.

Řešení included
