### PR TITLE
ContainerBuilder expander: check if param is nonempty

### DIFF
--- a/Nette/DI/ContainerBuilder.php
+++ b/Nette/DI/ContainerBuilder.php
@@ -49,6 +49,7 @@ class ContainerBuilder extends Nette\Object
 
 			$arguments = isset($definition['arguments']) ? $definition['arguments'] : array();
 			$expander = function(&$val) use ($container) {
+				if (!$val) return;
 				$val = $val[0] === '@' ? $container->getService(substr($val, 1)) : $container->expand($val);
 			};
 


### PR DESCRIPTION
ContainerBuilder expander: check if param is nonempty
$expander = function(&$val) use ($container) {
    if (!$val) return; //added this
    $val = $val[0] === '@' ? $container->getService(substr($val, 1)) : $container->expand($val);
};

http://forum.nette.org/cs/7854-nastavenie-pripojenia-nette-database#p59387
