### PR TITLE
changed Route::$flags access modifier to protected

### DIFF
--- a/Nette/Application/Routers/Route.php
+++ b/Nette/Application/Routers/Route.php
@@ -102,7 +102,7 @@ class Route extends Nette\Object implements Application\IRouter
 	private $type;
 
 	/** @var int */
-	private $flags;
+	protected $flags;
 
 
 


### PR DESCRIPTION
I changed Nette\Application\Routers\Route $flags attribute access modifier to protected, so it can be read by inherited class. Usage example: http://forum.nette.org/cs/4617-http-verbs-restful-architektura#p34558
