### PR TITLE
Diagnostics: add BlueScreen $footer messages

### DIFF
--- a/Nette/Diagnostics/templates/bluescreen.phtml
+++ b/Nette/Diagnostics/templates/bluescreen.phtml
@@ -309,8 +309,10 @@ $counter = 0;
 
 
 
+			<?php $bottomPanels = array() ?>
 			<?php foreach ($panels as $panel): ?>
 			<?php $panel = call_user_func($panel, $ex); if (empty($panel['tab']) || empty($panel['panel'])) continue; ?>
+			<?php if (isset($panel['bottom']) && $panel['bottom']) { $bottomPanels[] = $panel; continue; } ?>
 			<div class="panel">
 				<h2><a href="#" rel="netteBsPnl<?php echo ++$counter ?>"><?php echo htmlSpecialChars($panel['tab']) ?> <abbr>&#x25bc;</abbr></a></h2>
 
@@ -527,6 +529,17 @@ $counter = 0;
 			<p><i>no headers</i></p>
 			<?php endif ?>
 		</div></div>
+
+
+
+		<?php foreach ($bottomPanels as $panel): ?>
+		<div class="panel">
+			<h2><a href="#" rel="netteBsPnl<?php echo ++$counter ?>"><?php echo htmlSpecialChars($panel['tab']) ?> <abbr>&#x25bc;</abbr></a></h2>
+
+			<div id="netteBsPnl<?php echo $counter ?>" class="inner">
+			<?php echo $panel['panel'] ?>
+		</div></div>
+		<?php endforeach ?>
 
 
 		<ul>


### PR DESCRIPTION
Chtěl jsem ktomu napsat RFC na fórum ale to je mrtvé... :-(

Laděnka v Nette 2.0 je super cool vymazlená sexy holka! (možná i víc Sexy! než Texy!) :-)

Jedna věc mě ale oproti 0.9.x řadě chybí pokud si matně pamatuju tak Debug uměl něco jako addColophon nebo jak se to psalo. Což zapříčinilo přidávní vladní položky do „patičky“ v laděnce. Ve verzi 2.0 tahle fíčurka zmiznula a je ta tam! Proč?

Důvod proč se mě hodí:
- chci si do laděnky vkládat stejdžing informace
- chci tam mít informace o verzích dalších použitých knihoven

Protože pokud vlezu do log diru a koukám do aktuální laděnky vyčtu z nich verzi Nette což je cool ale nevičtu z nich verzi Doctrine a dalších knihoven.
