### PR TITLE
Allow default services to be overriden in static containers.

### DIFF
--- a/Nette/common/Configurator.php
+++ b/Nette/common/Configurator.php
@@ -41,8 +41,8 @@ class Configurator extends Object
 		$this->container->addService('container', $this->container);
 
 		foreach (get_class_methods($this) as $name) {
-			if (substr($name, 0, 13) === 'createService' ) {
-				$this->container->addService(strtolower($name[13]) . substr($name, 14), array(get_called_class(), $name));
+			if (substr($name, 0, 13) === 'createService' && $this->container->hasService($service = strtolower($name[13]) . substr($name, 14))) {
+				$this->container->addService($service, array(get_called_class(), $name));
 			}
 		}
 


### PR DESCRIPTION
During the container building phase, Nette\Configurator checks whether the container already contains the service which is being added. Allows to override default services in static container.
