### PR TITLE
Superfluous condition in Nette\Http\Request::getCookie

### DIFF
--- a/Nette/Http/Request.php
+++ b/Nette/Http/Request.php
@@ -184,10 +184,7 @@ class Request extends Nette\Object implements IRequest
 	 */
 	final public function getCookie($key, $default = NULL)
 	{
-		if (func_num_args() === 0) {
-			return $this->cookies;
-
-		} elseif (isset($this->cookies[$key])) {
+		if (isset($this->cookies[$key])) {
 			return $this->cookies[$key];
 
 		} else {


### PR DESCRIPTION
The condition is superfluous due to existence of the getCookies method that returns the very same cookies.
