### PR TITLE
Mail\MimePart: email address must not contain dash at the beginning

### DIFF
--- a/Nette/Mail/MimePart.php
+++ b/Nette/Mail/MimePart.php
@@ -77,7 +77,7 @@ class MimePart extends Nette\Object
 					throw new Nette\InvalidArgumentException("Name is not valid UTF-8 string.");
 				}
 
-				if (!preg_match('#^[^@",\s]+@[^@",\s]+\.[a-z]{2,10}$#i', $email)) {
+				if (!preg_match('#^[^-@",\s][^@",\s]+@[^@",\s]+\.[a-z]{2,10}$#i', $email)) {
 					throw new Nette\InvalidArgumentException("Email address '$email' is not valid.");
 				}
 

--- a/tests/Nette/Mail/Mail.headers.001.phpt
+++ b/tests/Nette/Mail/Mail.headers.001.phpt
@@ -31,3 +31,7 @@ Assert::throws(function() use ($mail) {
 Assert::throws(function() use ($mail) {
 	$mail->setHeader('n*ame', 'value');
 }, 'InvalidArgumentException', "Header name must be non-empty alphanumeric string, 'n*ame' given.");
+
+Assert::throws(function() use ($mail) {
+	$mail->setHeader('To', array('-foo@boo.com' => ''));
+}, 'InvalidArgumentException', "Email address '-foo@boo.com' is not valid.");


### PR DESCRIPTION
Emailová adresa by neměla na začátku obsahovat pomlčku. 

Smtp server pak vrací: SMTP server did not accept RCPT TO.
