### PR TITLE
fix output buffer when broken while printing debug bar

### DIFF
--- a/Nette/Diagnostics/Bar.php
+++ b/Nette/Diagnostics/Bar.php
@@ -55,6 +55,7 @@ class Bar extends Nette\Object
 	{
 		$panels = array();
 		foreach ($this->panels as $id => $panel) {
+			$obLevel = ob_get_level();
 			try {
 				$panels[] = array(
 					'id' => preg_replace('#[^a-z0-9]+#i', '-', $id),
@@ -68,6 +69,9 @@ class Bar extends Nette\Object
 					'panel' => nl2br(htmlSpecialChars((string) $e)),
 				);
 			}
+
+			// restore ob-level if broken by bar (e.g. in exception)
+			while(ob_get_level() > $obLevel) ob_end_clean();
 		}
 		require __DIR__ . '/templates/bar.phtml';
 	}


### PR DESCRIPTION
Debug panels often use template files which they "catch" using ob_ functions:
    $panelData = ...
    ob_start();
    include **DIR** . '/DebugPanel.phtml';
    return ob_get_clean();

But if there is an exception, output which was expected to be only in debug panel is suddenly outputed to web pages code. There may be try-catch in every panel to close ob handler, but one "master" check in Bar may be much easier. Bar already catches exceptions anyway, so it may "catch" also ob_ problems.

(I know, it's not very nice, but can be useful)
