### PR TITLE
Cache: fixed cache invalidation that depends on file during one request

### DIFF
--- a/Nette/Caching/Cache.php
+++ b/Nette/Caching/Cache.php
@@ -349,6 +349,7 @@ class Cache extends Nette\Object implements \ArrayAccess
 	 */
 	private static function checkFile($file, $time)
 	{
+		clearstatcache(TRUE, $file);
 		return @filemtime($file) == $time; // @ - stat may fail
 	}
 


### PR DESCRIPTION
Example:

Save some data

```
$cache = new Nette\Caching\Cache($fileStorage, 'NS');
$cache->save('key', 'data', array('files' => __DIR__ . '/file.txt'));
```

let some time pass and write something new

```
sleep(2);
file_put_contents(__DIR__ . '/file.txt', (string)microtime(TRUE));
```

here the file is changed, right? so it has different filemtime()
 let's make the cache loaded from file again

```
$cache->release();
```

and expect it to invalidate

```
assertNull($cache->load('key'));
```

Without this pull it wouldn't pass. I think, that this isn't expected behavior.
