### PR TITLE
Nette\Utils\Strings::substring - UTF-8 substring

### DIFF
--- a/Nette/Utils/Strings.php
+++ b/Nette/Utils/Strings.php
@@ -303,7 +303,7 @@ class Strings
 		if($length === null){
 			$length = self::length($s);
 		}
-		return function_exists('mb_substr') ? mb_substr($s, $offset, $length, 'UTF-8') : iconv_substr($s, $offset, $length, 'UTF-8');
+		return iconv_substr($s, $offset, $length, 'UTF-8');
 	}
 
 


### PR DESCRIPTION
Support for `substr` on UTF-8 strings. <del>Uses `mb_substr` if available, `iconv_substr` otherwise</del> <ins>Uses `iconv_substr`</ins>,
since `iconv` extension is required by Nette Framework, while `mbstring` is optional. <del>This provides an independant way.</del>
