### PR TITLE
Presenter: fixed bug - query param starting with "-" causes server error

### DIFF
--- a/Nette/Application/UI/Presenter.php
+++ b/Nette/Application/UI/Presenter.php
@@ -1172,7 +1172,7 @@ abstract class Presenter extends Control implements Application\IPresenter
 
 		foreach ($params as $key => $value) {
 			$a = strlen($key) > 2 ? strrpos($key, self::NAME_SEPARATOR, -2) : FALSE;
-			if ($a === FALSE) {
+			if (!$a) {
 				$selfParams[$key] = $value;
 			} else {
 				$this->globalParams[substr($key, 0, $a)][substr($key, $a + 1)] = $value;


### PR DESCRIPTION
Pokud použiji v url query param zacinajici pomlckou, zpusobi to pad nette. Resenim je 0 povazovat za nevyhovujici navratovou hodnotu strpos = na prvni pozici nesmi byt pomlcka. Url na web nette, kde je chyba tez nasimulovatelna radej nedavam, at se neplni error log. (=zkuste si to lokalne) :)
