### PR TITLE
Presenter::$invalidLinkMode is not overriden when application is created

### DIFF
--- a/Nette/common/Configurator.php
+++ b/Nette/common/Configurator.php
@@ -363,9 +363,11 @@ class Configurator extends Object
 		$context->addService('presenterFactory', $container->presenterFactory);
 		$context->addService('router', $container->router);
 
-		Nette\Application\UI\Presenter::$invalidLinkMode = $container->params['productionMode']
-			? Nette\Application\UI\Presenter::INVALID_LINK_SILENT
-			: Nette\Application\UI\Presenter::INVALID_LINK_WARNING;
+		if (Nette\Application\UI\Presenter::$invalidLinkMode === NULL) {
+			Nette\Application\UI\Presenter::$invalidLinkMode = $container->params['productionMode']
+				? Nette\Application\UI\Presenter::INVALID_LINK_SILENT
+				: Nette\Application\UI\Presenter::INVALID_LINK_WARNING;
+		}
 
 		$class = isset($options['class']) ? $options['class'] : 'Nette\Application\Application';
 		$application = new $class($context);


### PR DESCRIPTION
Configurator now respects the value of Nette\Application\UI\Presenter::$invalidLinkMode and does not change it if it was set before the application service is created.
