### PR TITLE
where('full condition') != where(array('full condition'))

### DIFF
--- a/Nette/Database/Table/Selection.php
+++ b/Nette/Database/Table/Selection.php
@@ -177,7 +177,11 @@ class Selection extends Nette\Object implements \Iterator, \ArrayAccess, \Counta
 	{
 		if (is_array($condition)) { // where(array('column1' => 1, 'column2 > ?' => 2))
 			foreach ($condition as $key => $val) {
-				$this->where($key, $val);
+				if (is_int($key)) {
+					$this->where($val);	// where('full condition')
+				} else {
+					$this->where($key, $val);	// where('column', 1)
+				}
 			}
 			return $this;
 		}


### PR DESCRIPTION
Where() when called with only a single argument - e.g. where('full condition'), behaves differently from when called with array('full condition'). The suggested patch resolves it.
