### PR TITLE
Debugger::$strictMode can determine severity of strictness

### DIFF
--- a/Nette/Diagnostics/Debugger.php
+++ b/Nette/Diagnostics/Debugger.php
@@ -65,7 +65,7 @@ final class Debugger
 	/** @var BlueScreen */
 	public static $blueScreen;
 
-	/** @var bool determines whether any error will cause immediate death */
+	/** @var bool|int determines whether any error will cause immediate death; if integer that it's matched against error severity */
 	public static $strictMode = FALSE; // $immediateDeath
 
 	/** @var bool disables the @ (shut-up) operator so that notices and warnings are no longer hidden */
@@ -467,7 +467,7 @@ final class Debugger
 		} elseif (($severity & error_reporting()) !== $severity) {
 			return FALSE; // calls normal error handler to fill-in error_get_last()
 
-		} elseif (self::$strictMode && !self::$productionMode) {
+		} elseif (!self::$productionMode && (is_bool(self::$strictMode) ? self::$strictMode : ((self::$strictMode & $severity) === $severity))) {
 			self::_exceptionHandler(new Nette\FatalErrorException($message, 0, $severity, $file, $line, $context));
 		}
 


### PR DESCRIPTION
We are all strict, but some are more strict than the others ;)

I need two severity levels in my app, one to kill the script (strict) and the other one just to warn me (normal). E.g. I want to see E_DEPRECATED, but not die on it; but die on E_NOTICE
