### PR TITLE
Rozšíření Nette\Forms\Controls\RadioList

### DIFF
--- a/Nette/Forms/Controls/RadioList.php
+++ b/Nette/Forms/Controls/RadioList.php
@@ -161,21 +161,23 @@ class RadioList extends BaseControl
 					case 'id':
 						$control->id = $label->for = $attrVal; break;
 					case 'label':
-						if ($attrVal instanceof Html)
+						if ($attrVal instanceof Html) {
 							$label->setHtml($attrVal);
-						else
+						} else {
 							$label->setText($this->translate((string) $attrVal));
-							
+						}
+						
 						break;
 					default:
 						$control->{$attr} = $attrVal; break;
 					}
 				}
 			} else {
-				if ($val instanceof Html)
-					$label->setHtml($val);
-				else
-					$label->setText($this->translate((string) $val));
+				if ($val instanceof Html) {
+					$label->setHtml($val);	
+				} else {
+					$label->setText($this->translate((string) $val));	
+				}
 			}
 
 			$container->add((string) $control . (string) $label . $separator);


### PR DESCRIPTION
Přidána možnost vložit do RadioListu nejen string|\Nette\Utils\Html, ale i array, který může obsahovat různé atributy (class, id, ...) a label. Samozřejmě lze i nadále vložit pouze string|\Nette\Utils\Html (zpětně kompatibilní).

S githubem teprve začínám tak doufám že jsem neudělal něco špatně :)
