### PR TITLE
Nette\Utils\Strings::substring - UTF-8 substr

### DIFF
--- a/Nette/Forms/Controls/TextInput.php
+++ b/Nette/Forms/Controls/TextInput.php
@@ -48,7 +48,7 @@ class TextInput extends TextBase
 	public function sanitize($value)
 	{
 		if ($this->control->maxlength && Nette\Utils\Strings::length($value) > $this->control->maxlength) {
-			$value = iconv_substr($value, 0, $this->control->maxlength, 'UTF-8');
+			$value = Nette\Utils\Strings::substring($value, 0, $this->control->maxlength);
 		}
 		return Nette\Utils\Strings::trim(strtr($value, "\r\n", '  '));
 	}

--- a/Nette/Templating/DefaultHelpers.php
+++ b/Nette/Templating/DefaultHelpers.php
@@ -41,7 +41,7 @@ final class DefaultHelpers
 		'url' => 'rawurlencode',
 		'striptags' => 'strip_tags',
 		'nl2br' => 'nl2br',
-		'substr' => 'iconv_substr',
+		'substr' => 'Nette\Utils\Strings::substring',
 		'repeat' => 'str_repeat',
 		'implode' => 'implode',
 		'number' => 'number_format',

--- a/Nette/Utils/Strings.php
+++ b/Nette/Utils/Strings.php
@@ -114,6 +114,23 @@ class Strings
 
 
 	/**
+	 * Returns a part of UTF-8 string.
+	 * @param string
+	 * @param int
+	 * @param int
+	 * @return string
+	 */
+	public static function substring($s, $offset, $length = null)
+	{
+		if($length === null){
+			$length = self::length($s);
+		}
+		return function_exists('mb_substr') ? mb_substr($s, $offset, $length, 'UTF-8') : iconv_substr($s, $offset, $length, 'UTF-8');
+	}
+
+
+
+	/**
 	 * Removes special controls characters and normalizes line endings and spaces.
 	 * @param  string  UTF-8 encoding or 8-bit
 	 * @return string
@@ -201,7 +218,7 @@ class Strings
 				return $matches[0] . $append;
 
 			} else {
-				return iconv_substr($s, 0, $maxLen, 'UTF-8') . $append;
+				return self::substring($s, 0, $maxLen) . $append;
 			}
 		}
 		return $s;
@@ -254,7 +271,7 @@ class Strings
 	 */
 	public static function firstUpper($s)
 	{
-		return self::upper(mb_substr($s, 0, 1, 'UTF-8')) . mb_substr($s, 1, self::length($s), 'UTF-8');
+		return self::upper(self::substring($s, 0, 1)) . self::substring($s, 1);
 	}
 
 
@@ -281,11 +298,11 @@ class Strings
 	public static function compare($left, $right, $len = NULL)
 	{
 		if ($len < 0) {
-			$left = iconv_substr($left, $len, -$len, 'UTF-8');
-			$right = iconv_substr($right, $len, -$len, 'UTF-8');
+			$left = self::substring($left, $len, -$len);
+			$right = self::substring($right, $len, -$len);
 		} elseif ($len !== NULL) {
-			$left = iconv_substr($left, 0, $len, 'UTF-8');
-			$right = iconv_substr($right, 0, $len, 'UTF-8');
+			$left = self::substring($left, 0, $len);
+			$right = self::substring($right, 0, $len);
 		}
 		return self::lower($left) === self::lower($right);
 	}
@@ -329,7 +346,7 @@ class Strings
 	{
 		$length = max(0, $length - self::length($s));
 		$padLen = self::length($pad);
-		return str_repeat($pad, $length / $padLen) . iconv_substr($pad, 0, $length % $padLen, 'UTF-8') . $s;
+		return str_repeat($pad, $length / $padLen) . self::substring($pad, 0, $length % $padLen) . $s;
 	}
 
 
@@ -345,7 +362,7 @@ class Strings
 	{
 		$length = max(0, $length - self::length($s));
 		$padLen = self::length($pad);
-		return $s . str_repeat($pad, $length / $padLen) . iconv_substr($pad, 0, $length % $padLen, 'UTF-8');
+		return $s . str_repeat($pad, $length / $padLen) . self::substring($pad, 0, $length % $padLen);
 	}
 
 


### PR DESCRIPTION
According to DZone article (http://css.dzone.com/news/iconvsubstr-vs-mbstringsubstr), using `mb_substr` is much faster than using `iconv_substr`. However, only `iconv` is required by Nette Requiremends Checker, while `mbstring` extension is optional. (see #355)

This solution provides independant way - using `mb_substr` (faster) if available or fallback to `iconv_substr`.

Also, all occurences of either `mb_substr` or `iconv_substr` in Nette are replaced in this commit, and so is the `substr` template helper.
