### PR TITLE
Fix for fully specified class names in PHP 5.3 that are not properly tran

### DIFF
--- a/client-side/forms/netteForms.js
+++ b/client-side/forms/netteForms.js
@@ -128,6 +128,7 @@ Nette.validateRule = function(elem, op, arg) {
 		op = op.substr(1);
 	}
 	op = op.replace('::', '_');
+  op = op.replace('\\', '');
 	return Nette.validators[op] ? Nette.validators[op](elem, arg, val) : null;
 };
 


### PR DESCRIPTION
Fix for fully specified class names in PHP 5.3 that are not properly translated to name of JS validation function.

Example:
$form->addText('sum', 'Sum')->addRule('\Validators\GeneralValidators::Sum',...);

Nette forum: http://forum.nette.org/en/928-how-to-use-callback-in-the-form-of-fully-specified-class-name-with-method-name-for-js-validation
