### PR TITLE
$_POST["action"] při ajaxovém požadavku přepisuje základní action p

### DIFF
--- a/Nette/Application/UI/Presenter.php
+++ b/Nette/Application/UI/Presenter.php
@@ -1167,7 +1167,7 @@ abstract class Presenter extends Control implements Application\IPresenter
 
 		$params = $this->request->getParams();
 		if ($this->isAjax()) {
-			$params = $this->request->getPost() + $params;
+			$params += $this->request->getPost();
 		}
 
 		foreach ($params as $key => $value) {


### PR DESCRIPTION
$_POST["action"] při ajaxovém požadavku přepisuje základní action proměnnou získanou z routy. Více na http://forum.nette.org/cs/8336-promenna-post-action-a-jine-chovani-pod-ajax-modem
