### PR TITLE
ConnectionPanel: skip unwanted items in backtrace

### DIFF
--- a/Nette/Database/Diagnostics/ConnectionPanel.php
+++ b/Nette/Database/Diagnostics/ConnectionPanel.php
@@ -64,6 +64,8 @@ class ConnectionPanel extends Nette\Object implements Nette\Diagnostics\IBarPane
 		$source = NULL;
 		foreach (debug_backtrace(FALSE) as $row) {
 			if (isset($row['file']) && is_file($row['file']) && strpos($row['file'], NETTE_DIR . DIRECTORY_SEPARATOR) !== 0) {
+				if (isset($row['function']) && strpos($row['function'], 'call_user_func') === 0) continue;
+				if (isset($row['class']) && is_subclass_of($row['class'], '\\Nette\\Database\\Connection')) continue;
 				$source = array($row['file'], (int) $row['line']);
 				break;
 			}


### PR DESCRIPTION
ve výpisu zdroje přeskakuje nepřímá volání přes call_user_func[_array] a volání z potomka Connection
