### PR TITLE
Strings::substring doesn't work with length = NULL

### DIFF
--- a/Nette/Utils/Strings.php
+++ b/Nette/Utils/Strings.php
@@ -123,7 +123,7 @@ class Strings
 	public static function substring($s, $start, $length = NULL)
 	{
 		if ($length === NULL) {
-			$length = PHP_INT_MAX;
+			$length = function_exists('mb_strlen') ? mb_strlen($s) : iconv_strlen($s);
 		}
 		return function_exists('mb_substr') ? mb_substr($s, $start, $length, 'UTF-8') : iconv_substr($s, $start, $length, 'UTF-8');
 	}


### PR DESCRIPTION
length with PHP_INT_MAX doesn't work for me. This is the similar problem http://www.php.net/manual/en/function.mb-substr.php#77515
