### PR TITLE
Neon::encode: fixed encoding of empty array

### DIFF
--- a/Nette/Utils/Neon.php
+++ b/Nette/Utils/Neon.php
@@ -72,6 +72,9 @@ class Neon extends Nette\Object
 			$isArray = array_keys($var) === range(0, count($var) - 1);
 			$s = '';
 			if ($options & self::BLOCK) {
+				if (count($var) === 0){
+					return "[]";
+				}
 				foreach ($var as $k => $v) {
 					$v = self::encode($v, self::BLOCK);
 					$s .= ($isArray ? '-' : self::encode($k) . ':')


### PR DESCRIPTION
Mám tento kód:

```
\Nette\Config\NeonAdapter::save(array("key"=>array()), $this->context->params["tempDir"]."/test.neon");
```

v test.neon najdu:

```
# generated by Nette

key:
```

což je po načtení ekvivalentní k $config[„key“] = NULL. Jako správný výstup bych očekával toto:

```
# generated by Nette

key: []
```
