### PR TITLE
Latte: support for {else} in {if} with condition in closing tag

### DIFF
--- a/Nette/Latte/Macros/CoreMacros.php
+++ b/Nette/Latte/Macros/CoreMacros.php
@@ -45,14 +45,13 @@ use Nette,
 class CoreMacros extends MacroSet
 {
 
-
 	public static function install(Latte\Parser $parser)
 	{
 		$me = new static($parser);
 
 		$me->addMacro('if', array($me, 'macroIf'), array($me, 'macroEndIf'));
 		$me->addMacro('elseif', 'elseif (%node.args):');
-		$me->addMacro('else', 'else:');
+		$me->addMacro('else', array($me, 'macroElse'));
 		$me->addMacro('ifset', 'if (isset(%node.args)):', 'endif');
 		$me->addMacro('elseifset', 'elseif (isset(%node.args)):');
 
@@ -128,9 +127,31 @@ class CoreMacros extends MacroSet
 			if ($node->args === '') {
 				throw new ParseException('Missing condition in {if} macro.');
 			}
-			return $writer->write('if (%node.args) ob_end_flush(); else ob_end_clean()');
+			return $writer->write('if (%node.args) { '
+				. (isset($node->data->else) ? 'ob_end_clean(); ' : '')
+				. 'ob_end_flush(); } else { '
+				. (isset($node->data->else) ? '$_else = ob_get_contents(); ob_end_clean(); ob_end_clean(); echo $_else;' : 'ob_end_clean();')
+				. ' }');
 		}
 		return 'endif';
+	}
+
+
+
+	/**
+	 * {else}
+	 */
+	public function macroElse(MacroNode $node, $writer)
+	{
+		$ifNode = $node->parentNode;
+		if ($ifNode->data->capture) {
+			if (isset($ifNode->data->else)) {
+				throw new ParseException("Macro {if} supports only one {else}.");
+			}
+			$ifNode->data->else = TRUE;
+			return 'ob_start()';
+		}
+		return 'else:';
 	}
 
 


### PR DESCRIPTION
It is not possible to use `{else}` branch in `{if}` block with condition in closing tag, because opening tag includes only `ob_start()`. I suppose using `{else}` is useful feature and quite common need, but now the only way is via using `$iterations` variable in extra `{if}` to create such branch, which is kind of magic.

With this fix it is possible to write code like this:

``` php
{if}
    {foreach $posts as $post}
        {$post->title}
    {/foreach}
{else}
    No posts.
{/if $iterations}
```
