### PR TITLE
Revert "Fixed compatibility with PHP 5.4 (get_magic_quotes_gpc now raise...s E_DEPRECATED)"

### DIFF
--- a/Nette/Http/RequestFactory.php
+++ b/Nette/Http/RequestFactory.php
@@ -135,7 +135,7 @@ class RequestFactory extends Nette\Object
 		$post = $useFilter ? filter_input_array(INPUT_POST, FILTER_UNSAFE_RAW) : (empty($_POST) ? array() : $_POST);
 		$cookies = $useFilter ? filter_input_array(INPUT_COOKIE, FILTER_UNSAFE_RAW) : (empty($_COOKIE) ? array() : $_COOKIE);
 
-		$gpc = (bool) @get_magic_quotes_gpc(); // @ - deprecated since PHP 5.4.0
+		$gpc = (bool) get_magic_quotes_gpc();
 		$old = error_reporting(error_reporting() ^ E_NOTICE);
 
 		// remove fucking quotes and check (and optionally convert) encoding


### PR DESCRIPTION
This change is no longer needed since get_magic_quotes_gpc does not throw deprecation warning.

See https://bugs.php.net/bug.php?id=55371 and http://news.php.net/php.internals/56332.
