### PR TITLE
Session: bugfix - session won't really open when closed and opened again

### DIFF
--- a/Nette/Http/Session.php
+++ b/Nette/Http/Session.php
@@ -83,13 +83,11 @@ class Session extends Nette\Object
 
 		$this->configure($this->options);
 
-		if (!defined('SID')) {
-			Nette\Diagnostics\Debugger::tryError();
-			session_start();
-			if (Nette\Diagnostics\Debugger::catchError($e)) {
-				@session_write_close(); // this is needed
-				throw new Nette\InvalidStateException('session_start(): ' . $e->getMessage(), 0, $e);
-			}
+		Nette\Diagnostics\Debugger::tryError();
+		session_start();
+		if (Nette\Diagnostics\Debugger::catchError($e)) {
+			@session_write_close(); // this is needed
+			throw new Nette\InvalidStateException('session_start(): ' . $e->getMessage(), 0, $e);
 		}
 
 		self::$started = TRUE;


### PR DESCRIPTION
při uzavření a opětovném otevření Nette\Session se nezavolá funkce session_start(). session se tváří jako otevřená, ale ve skutečnosti není. data se nezapíšou
