### PR TITLE
Method isControlInvalid does not "see" through ComponentContainer

### DIFF
--- a/Nette/Application/UI/Control.php
+++ b/Nette/Application/UI/Control.php
@@ -183,12 +183,21 @@ abstract class Control extends PresenterComponent implements IPartiallyRenderabl
 				return TRUE;
 
 			} else {
-				foreach ($this->getComponents() as $component) {
-					if ($component instanceof IRenderable && $component->isControlInvalid()) {
-						// $this->invalidSnippets['__child'] = TRUE; // as cache
-						return TRUE;
+				$queue = array($this);
+				do {
+					foreach (array_shift($queue)->getComponents() as $component) {
+						if ($component instanceof IRenderable) {
+							if ($component->isControlInvalid()) {
+								// $this->invalidSnippets['__child'] = TRUE; // as cache
+								return TRUE;
+							}
+
+						} elseif ($component instanceof Nette\ComponentModel\IContainer) {
+							$queue[] = $component;
+						}
 					}
-				}
+				} while ($queue);
+
 				return FALSE;
 			}
 

--- a/tests/Nette/Application.UI/Control.isControlInvalid.phpt
+++ b/tests/Nette/Application.UI/Control.isControlInvalid.phpt
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Test: Nette\Application\UI\Control::isControlInvalid()
+ *
+ * @author     Jan Tvrdík
+ * @package    Nette\Application\UI
+ * @subpackage UnitTests
+ */
+
+use Nette\Application\UI;
+
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+
+class TestControl extends UI\Control
+{
+
+}
+
+
+
+$control = new TestControl();
+$child = new TestControl();
+$control->addComponent($child, 'foo');
+
+Assert::false($control->isControlInvalid());
+$child->invalidateControl();
+Assert::true($control->isControlInvalid());
+
+
+$control = new TestControl();
+$child = new Nette\ComponentModel\Container();
+$grandChild = new TestControl();
+$control->addComponent($child, 'foo');
+$child->addComponent($grandChild, 'bar');
+
+Assert::false($control->isControlInvalid());
+$grandChild->invalidateControl();
+Assert::true($control->isControlInvalid());


### PR DESCRIPTION
If a component is not a direct descendant (in component tree) of presenter but is a child of `ComponentContainer` (which is child of some presenter) then after component invalidation the presenter is not invalidated even though it should be because method `isControlInvalid` does not "go through" `ComponentContainer` (because it does not implement `IRenderable`).
