### PR TITLE
idea - check template parameters for reserved names

### DIFF
--- a/Nette/Application/UI/Control.php
+++ b/Nette/Application/UI/Control.php
@@ -88,6 +88,9 @@ abstract class Control extends PresenterComponent implements IRenderable
 			$template->flashes = array();
 		}
 
+		// move to user-space phase and thus enable some checks
+		$template->setPhase(\Nette\Templating\Template::PHASE_USER_SPACE);
+
 		return $template;
 	}
 


### PR DESCRIPTION
This is just an idea which helped me, as i often forgot which variables in templates are used by framework.
Sometimes i use the same variable in presenter not realizing it's already there, and thus make a collision and the app stops working (e.g. in presenter which takes care about user administration, I assign `$this->template->user = ...` and it breaks the whole page, because user is already assigned and expected to be of IUser).

This will emit an E_NOTICE when assigning to a reserved parameter, showing that the problem is in presenter in code I mentioned above (and not somewhere else as it screams now).

(perhaps this is not the prettiest impl as it's very recent idea, suggestions are welcome)
