### PR TITLE
argsToParams access modifier changed to protected

### DIFF
--- a/Nette/Application/UI/Presenter.php
+++ b/Nette/Application/UI/Presenter.php
@@ -995,7 +995,7 @@ abstract class Presenter extends Control implements Application\IPresenter
 	 * @return void
 	 * @throws InvalidLinkException
 	 */
-	private static function argsToParams($class, $method, & $args, $supplemental = array())
+	protected static function argsToParams($class, $method, & $args, $supplemental = array())
 	{
 		static $cache;
 		$params = & $cache[strtolower($class . ':' . $method)];


### PR DESCRIPTION
I need to call argsToParams in my presenter descendant in order to normalize Presenter::link $args, which this commit allows.

Usage: I implemented annotation @secured to protect signals from CSRF(overrode link and signalRecieved methods). I am generating security token from user ID, signal name and signal arguments. In template I can pass arguments into link just by setting values (e.g. {plink dummySignal! $value}) or by specifying names ({plink dummySignal! 'param1' => $value}) and by this usage I am getting 2 different $args arrays(one regular, second associative) from which I calculate hash. By normalizing $args using argsToParams method I am allowed to use both variants. Otherwise hashes are different.

Reason I need to calculate hash from these values is to have it user/signal/arguments independent.
