### PR TITLE
Výchozí persistentní parametr z configu

### DIFF
--- a/Nette/Application/UI/PresenterComponentReflection.php
+++ b/Nette/Application/UI/PresenterComponentReflection.php
@@ -48,12 +48,12 @@ class PresenterComponentReflection extends Nette\Reflection\ClassType
 		if (is_subclass_of($class, 'Nette\Application\UI\PresenterComponent')) {
 			// $class::getPersistentParams() in PHP 5.3
 			$defaults = get_class_vars($class);
-			foreach (call_user_func(array($class, 'getPersistentParams'), $class) as $name => $meta) {
-				if (is_string($meta)) {
-					$name = $meta;
+			foreach (call_user_func(array($class, 'getPersistentParams'), $class) as $name => $default) {
+				if (is_int($name)) {
+					$name = $default;
 				}
 				$params[$name] = array(
-					'def' => $defaults[$name],
+					'def' => is_int($name) ? $defaults[$name] : $default,
 					'since' => $class,
 				);
 			}


### PR DESCRIPTION
getPersistentParams() může vracet asociativní pole (property-name => default-value) a tím načítat třeba defaultní jazyk z configu. Vychází z diskuse  http://forum.nette.org/cs/9195 

příklad:
function getPersistentParams(){
  return array('lang' => $this->context->db->settings->getDefaultLang());
}
