### PR TITLE
fix unreachable condition: User::getRoles returns authenticatedRole if a...

### DIFF
--- a/Nette/Http/User.php
+++ b/Nette/Http/User.php
@@ -351,8 +351,8 @@ class User extends Nette\Object implements IUser
 			return array($this->guestRole);
 		}
 
-		$identity = $this->getIdentity();
-		return $identity ? $identity->getRoles() : array($this->authenticatedRole);
+		$roles = $this->getIdentity()->getRoles();
+		return $roles ? $roles : array($this->authenticatedRole);
 	}
 
 


### PR DESCRIPTION
...uthentizator returns no roles

Toto se týká jen případu, kdy  je uživatel přihlášen authenticatorem, který  při volání new Identity ji nepředá žádné role.

Potom  user->getRoles() vrátí prázdné pole. Po opravě vrací user::authenticatedrole.
