### PR TITLE
Macro {snippet} supports HTML attributes

### DIFF
--- a/Nette/Latte/Macros/UIMacros.php
+++ b/Nette/Latte/Macros/UIMacros.php
@@ -254,7 +254,7 @@ if (!empty($_control->snippetMode)) {
 				$tag = $tag ? $tag : 'div';
 				$node->data->leave = TRUE;
 				$node->data->end = "\$_dynSnippets[\$_dynSnippetId] = ob_get_flush() ?>\n</$tag><?php";
-				return $writer->write("?>\n<$tag id=\"<?php echo \$_dynSnippetId = \$_control->getSnippetId({$writer->formatWord($name)}) ?>\"><?php ob_start()");
+				return $writer->write("?>\n<?php echo Nette\Utils\Html::el('$tag id=\"'.(\$_dynSnippetId = \$control->getSnippetId({$writer->formatWord($name)}).'\"')->addAttributes(%node.array)->startTag(); ob_start()");
 
 			} else {
 				$node->data->leave = TRUE;
@@ -286,7 +286,7 @@ if (!empty($_control->snippetMode)) {
 		if ($node->name === 'snippet') {
 			$tag = trim($node->tokenizer->fetchWord(), '<>');
 			$tag = $tag ? $tag : 'div';
-			return $writer->write("?>\n<$tag id=\"<?php echo \$_control->getSnippetId(%var) ?>\"><?php $include ?>\n</$tag><?php ",
+			return $writer->write("?>\n<?php echo Nette\Utils\Html::el('$tag id=\"'.\$control->getSnippetId(%var).'\"')->addAttributes(%node.array)->startTag(); $include ?>\n</$tag><?php ",
 				(string) substr($name, 1), $name
 			);
 

--- a/tests/Nette/Latte/expected/macros.snippet.phtml
+++ b/tests/Nette/Latte/expected/macros.snippet.phtml
@@ -13,7 +13,7 @@ if (!function_exists($_l->blocks['_'][] = '%a%__')) { function %a%__($_l, $_args
 if (!function_exists($_l->blocks['_outer'][] = '%a%__outer')) { function %a%__outer($_l, $_args) { extract($_args); $_control->validateControl('outer')
 ?>
 	Outer
-		<div id="<?php echo $_control->getSnippetId('inner') ?>"><?php call_user_func(reset($_l->blocks['_inner']), $_l, $template->getParameters()) ?>
+		<?php echo Nette\Utils\Html::el('div id="'.$_control->getSnippetId('inner').'"')->addAttributes(array())->startTag(); call_user_func(reset($_l->blocks['_inner']), $_l, $template->getParameters()) ?>
 </div>
 	/Outer
 <?php
@@ -41,24 +41,34 @@ if (!function_exists($_l->blocks['_title2'][] = '%a%__title2')) { function %a%__
 }}
 
 //
+// block _title3
+//
+if (!function_exists($_l->blocks['_title3'][] = '%a%__title3')) { function %a%__title3($_l, $_args) { extract($_args); $_control->validateControl('title3')
+?>Title 3<?php
+}}
+
+//
 // end of blocks
 %A%
 	return Nette\Latte\Macros\UIMacros::renderSnippets($_control, $_l, get_defined_vars());
 %A%
-<div id="<?php echo $_control->getSnippetId('') ?>"><?php call_user_func(reset($_l->blocks['_']), $_l, $template->getParameters()) ?>
+echo Nette\Utils\Html::el('div id="'.$_control->getSnippetId('').'"')->addAttributes(array())->startTag(); call_user_func(reset($_l->blocks['_']), $_l, $template->getParameters()) ?>
 </div>
 
 
-<div id="<?php echo $_control->getSnippetId('outer') ?>"><?php call_user_func(reset($_l->blocks['_outer']), $_l, $template->getParameters()) ?>
+<?php echo Nette\Utils\Html::el('div id="'.$_control->getSnippetId('outer').'"')->addAttributes(array())->startTag(); call_user_func(reset($_l->blocks['_outer']), $_l, $template->getParameters()) ?>
 </div>
 
 
 	@<?php if (true): ?> Hello World @<?php endif ?>
 
 
-	<h2 id="<?php echo $_control->getSnippetId('title') ?>"><?php call_user_func(reset($_l->blocks['_title']), $_l, $template->getParameters()) ?>
+	<?php echo Nette\Utils\Html::el('h2 id="'.$_control->getSnippetId('title').'"')->addAttributes(array())->startTag(); call_user_func(reset($_l->blocks['_title']), $_l, $template->getParameters()) ?>
 </h2>
 
-	<h2 id="<?php echo $_control->getSnippetId('title2') ?>"><?php call_user_func(reset($_l->blocks['_title2']), $_l, $template->getParameters()) ?>
+	<?php echo Nette\Utils\Html::el('h2 id="'.$_control->getSnippetId('title2').'"')->addAttributes(array())->startTag(); call_user_func(reset($_l->blocks['_title2']), $_l, $template->getParameters()) ?>
+</h2>
+
+	<?php echo Nette\Utils\Html::el('h2 id="'.$_control->getSnippetId('title3').'"')->addAttributes(array('class' => 'foo'))->startTag(); call_user_func(reset($_l->blocks['_title3']), $_l, $template->getParameters()) ?>
 </h2>
 %A%

--- a/tests/Nette/Latte/templates/snippet.latte
+++ b/tests/Nette/Latte/templates/snippet.latte
@@ -17,3 +17,5 @@
 	{snippet title h2}Title 1{/snippet title}
 
 	{snippet title2 <h2>}Title 2{/snippet}
+
+	{snippet title3 h2 class => 'foo'}Title 3{/snippet}


### PR DESCRIPTION
Implementation requires to use the element name if attributes are defined (otherwise it will break horribly i guess).

`macros.snippet.phpt` fails, but it was already failing before this alternation.

Example:

`{snippet foo div class => 'bar'}`
