### PR TITLE
ContainerBuilder: findByTag now intentionally ignores non-shared services

### DIFF
--- a/Nette/DI/ContainerBuilder.php
+++ b/Nette/DI/ContainerBuilder.php
@@ -145,7 +145,7 @@ class ContainerBuilder extends Nette\Object
 	{
 		$found = array();
 		foreach ($this->definitions as $name => $def) {
-			if (isset($def->tags[$tag])) {
+			if (isset($def->tags[$tag]) && $def->shared) {
 				$found[$name] = $def->tags[$tag];
 			}
 		}

--- a/tests/Nette/DI/ContainerBuilder.findByTag.phpt
+++ b/tests/Nette/DI/ContainerBuilder.findByTag.phpt
@@ -22,7 +22,13 @@ $builder->addDefinition('one')
 $builder->addDefinition('two')
 	->setClass('stdClass')
 	->addTag('debugPanel', TRUE);
-
+$builder->addDefinition('three')
+	->setClass('stdClass')
+	->addTag('component');
+$builder->addDefinition('four')
+	->setClass('stdClass')
+	->addTag('component')
+	->setParameters(array()); // shared = FALSE
 $builder->addDefinition('five')
 	->setClass('stdClass')
 	->addTag('debugPanel', array(1, 2, 3))
@@ -38,6 +44,10 @@ Assert::same( array(
 	'two' => TRUE,
 	'five' => array(1, 2, 3),
 ), $builder->findByTag('debugPanel') );
+
+Assert::same( array(
+	'three' => TRUE,
+), $builder->findByTag('component') );
 
 Assert::same( array(), $builder->findByTag('unknown') );
 


### PR DESCRIPTION
```
$containerBuilder->addDefinition('foo')
    ->setParameters(array())
    ->addTag('component')
```

results in error

```
$containerBuilder->findByTag('component');
// array(
//    foo => TRUE,
//    fooFactory => TRUE,
// )
```
