### PR TITLE
Class 'Nette\Http\IUserStorage' not found

### DIFF
--- a/Nette/Http/User.php
+++ b/Nette/Http/User.php
@@ -11,7 +11,8 @@
 
 namespace Nette\Http;
 
-use Nette;
+use Nette,
+	Nette\Security\IUserStorage;
 
 
 


### PR DESCRIPTION
Nette\Http\User back compatibility fix
