### PR TITLE
NetteLoader: backslash causes an error when loading files on Mac OS X

### DIFF
--- a/Nette/Loaders/NetteLoader.php
+++ b/Nette/Loaders/NetteLoader.php
@@ -109,7 +109,7 @@ class NetteLoader extends AutoLoader
 			self::$count++;
 
 		}/**/ elseif (substr($type, 0, 6) === 'Nette\\') {
-			Nette\Utils\LimitedScope::load(NETTE_DIR . substr($type, 5) . '.php', TRUE);
+			Nette\Utils\LimitedScope::load(NETTE_DIR . str_replace('\\', '/', substr($type, 5)) . '.php', TRUE);
 			self::$count++;
 		}/**/
 	}


### PR DESCRIPTION
After this commit https://github.com/nette/nette/commit/afce066f9310a924fbc1c6087c6f0d8ff217c8ad

LimitedScope::load causes an error when including a file with backslash

```
[Sun Jan 15 13:52:17 2012] [error] [client 127.0.0.1] PHP Warning:  include_once(/Volumes/Data/www-dev/nette/Nette\\Diagnostics\\Debugger.php): failed to open stream: No such file or directory in /Volumes/Data/www-dev/nette/Nette/Utils/LimitedScope.php on line 69
[Sun Jan 15 13:52:17 2012] [error] [client 127.0.0.1] PHP Warning:  include_once(): Failed opening '/Volumes/Data/www-dev/nette/Nette\\Diagnostics\\Debugger.php' for inclusion (include_path='.:') in /Volumes/Data/www-dev/nette/Nette/Utils/LimitedScope.php on line 69
[Sun Jan 15 13:52:17 2012] [error] [client 127.0.0.1] PHP Fatal error:  Class 'Nette\\Diagnostics\\Debugger' not found in /Volumes/Data/www-dev/nette/Nette/loader.php on line 58
```
