### PR TITLE
Caching\Storages\FileStorage: added `umask(0000)` to write() method

### DIFF
--- a/Nette/Caching/Storages/FileStorage.php
+++ b/Nette/Caching/Storages/FileStorage.php
@@ -182,6 +182,8 @@ class FileStorage extends Nette\Object implements Nette\Caching\IStorage
 	 */
 	public function write($key, $data, array $dp)
 	{
+		umask(0000);
+
 		$meta = array(
 			self::META_TIME => microtime(),
 		);


### PR DESCRIPTION
Při ukládání souborů u mě docházelo k zápisu s právy 644 na webu (apache) a 664 při spuštění v konzoli (aktuální uživatel) - tohle chování se může imho lišit stroj od stroje - v závislosti na systémovém resp. uživatelově nastavení umask. Proto je dobré zapisovat vše s právy 666.
