### PR TITLE
Fixed 'run' parameter in config (boolean value matters)

### DIFF
--- a/Nette/Config/Compiler.php
+++ b/Nette/Config/Compiler.php
@@ -327,7 +327,9 @@ class Compiler extends Nette\Object
 		}
 
 		if (isset($config['run'])) {
-			$config['tags']['run'] = (bool) $config['run'];
+			if ($run = (bool) $config['run']) {
+				$config['tags']['run'] = $run;
+			}
 		}
 
 		if (isset($config['tags'])) {


### PR DESCRIPTION
Current implementation does not take into acount the value of `run` parameter of service. With this fix it is possible to overwrite earlier `run: yes` by `run: no`. I guess that is desired functionality.
