### PR TITLE
NetteExtension: added missing parameter 'productionMode'=>'%productionMode%' 

### DIFF
--- a/Nette/Config/Extensions/NetteExtension.php
+++ b/Nette/Config/Extensions/NetteExtension.php
@@ -53,6 +53,7 @@ class NetteExtension extends Nette\Config\CompilerExtension
 		'forms' => array(
 			'messages' => array(),
 		),
+		'productionMode' => '%productionMode%',
 	);
 
 	public $databaseDefaults = array(


### PR DESCRIPTION
(caused empty($config['productionMode'] always TRUE) (caused Panels to load even in productionMode)

Příklad User:
Předtím v poli $config prostě productionMode nebyl. neinicializovaná proměnná

```
$config = $this->getConfig($this->defaults);
...
if (empty($config['productionMode']) && $config['security']['debugger']) {
            $user->addSetup('Nette\Diagnostics\Debugger::$bar->addPanel(?)', array(
                new Nette\DI\Statement('Nette\Security\Diagnostics\UserPanel')
            ));
        }
```

PS: taky by to šlo řešit v loadconfiguration pomocí $config['productionMode']=$this->containerBuilder->parameters['productionMode']. Tahle varianta neumožní nastavit productionmode přes config.neon, otázka je, koho by to napadlo, případně zda je správné to zakázat či povolit.
