### PR TITLE
Session::exists() does not work with changed session_name

### DIFF
--- a/Nette/Http/Session.php
+++ b/Nette/Http/Session.php
@@ -223,7 +223,7 @@ class Session extends Nette\Object
 	 */
 	public function exists()
 	{
-		return self::$started || $this->request->getCookie(session_name()) !== NULL;
+		return self::$started || $this->request->getCookie($this->getName()) !== NULL;
 	}
 
 
@@ -284,7 +284,7 @@ class Session extends Nette\Object
 	 */
 	public function getName()
 	{
-		return session_name();
+		return isset($this->options['name']) ? $this->options['name'] : session_name();
 	}
 
 


### PR DESCRIPTION
``` php
$session->setOptions(array('name' => 'mysessid'));
var_dump($session->exists());
$session->start();
```

Even after refreshing page output is false, because Sesssion::exists() is checking for cookie named PHPSESSID instead of myssesid.

There is alternative fix https://github.com/lm/nette/commit/a6fe3963bda6e5bc76ed3894978bb24b09accf24.
