### PR TITLE
Diagnostics\Bar: fixed HTML code for panel if throws Exception  

### DIFF
--- a/Nette/Diagnostics/Bar.php
+++ b/Nette/Diagnostics/Bar.php
@@ -65,9 +65,9 @@ class Bar extends Nette\Object
 				);
 			} catch (\Exception $e) {
 				$panels[] = array(
-					'id' => "error-$id",
+					'id' => "error-" . preg_replace('#[^a-z0-9]+#i', '-', $id),
 					'tab' => "Error: $id",
-					'panel' => nl2br(htmlSpecialChars((string) $e)),
+					'panel' => '<div class="nette-inner">' . nl2br(htmlSpecialChars((string) $e)) . '</div>',
 				);
 				while (ob_get_level() > $obLevel) { // restore ob-level if broken
 					ob_end_clean();


### PR DESCRIPTION
(například chybu hází userPanel, když mám session. Tipuji to na nějaký garbage collection a register_shutdown..)

K věci: 
v opeře se v případě chyby nevykreslí celý debugpanel, jinde třeba jo, ale dlouhý text chyby překryje obrazovku.
