### PR TITLE
Dynamic snippets: only they are put to payload

### DIFF
--- a/tests/Nette/Latte/expected/macros.dynamicsnippets.alt.phtml
+++ b/tests/Nette/Latte/expected/macros.dynamicsnippets.alt.phtml
@@ -8,10 +8,10 @@ list($_l, $_g) = Nette\Latte\Macros\CoreMacros::initRuntime($template, 'xxx')
 //
 if (!function_exists($_l->blocks['_outer1'][] = '_xxx__outer1')) { function _xxx__outer1($_l, $_args) { extract($_args); $_control->validateControl('outer1')
 ;$iterations = 0; foreach (array(1,2,3) as $id): ?>
-		<div<?php echo ' id="' . ($_dynSnippetId = $_control->getSnippetId("inner-$id")) . '"' ?>>
+		<div<?php echo ' id="' . ($_control->getSnippetId("inner-$id")) . '"' ?>>
 <?php ob_start() ?>				#<?php echo Nette\Templating\Helpers::escapeHtml($id, ENT_NOQUOTES) ?>
 
-<?php $_dynSnippets[$_dynSnippetId] = ob_get_flush() ?>		</div>
+<?php $_dynSnippets["inner-$id"] = ob_get_flush() ?>		</div>
 <?php $iterations++; endforeach ?>
 	<?php if (isset($_dynSnippets)) return $_dynSnippets;
 }}
@@ -21,10 +21,10 @@ if (!function_exists($_l->blocks['_outer1'][] = '_xxx__outer1')) { function _xxx
 //
 if (!function_exists($_l->blocks['_outer2'][] = '_xxx__outer2')) { function _xxx__outer2($_l, $_args) { extract($_args); $_control->validateControl('outer2')
 ;$iterations = 0; foreach (array(1,2,3) as $id): ?>
-		<div<?php echo ' id="' . ($_dynSnippetId = $_control->getSnippetId("inner-$id")) . '"' ?>>
+		<div<?php echo ' id="' . ($_control->getSnippetId("inner-$id")) . '"' ?>>
 <?php ob_start() ?>				#<?php echo Nette\Templating\Helpers::escapeHtml($id, ENT_NOQUOTES) ?>
 
-<?php $_dynSnippets[$_dynSnippetId] = ob_get_flush() ?>		</div>
+<?php $_dynSnippets["inner-$id"] = ob_get_flush() ?>		</div>
 <?php $iterations++; endforeach ?>
 	<?php if (isset($_dynSnippets)) return $_dynSnippets;
 }}

--- a/tests/Nette/Latte/expected/macros.dynamicsnippets.phtml
+++ b/tests/Nette/Latte/expected/macros.dynamicsnippets.phtml
@@ -8,10 +8,10 @@ list($_l, $_g) = Nette\Latte\Macros\CoreMacros::initRuntime($template, 'xxx')
 //
 if (!function_exists($_l->blocks['_outer'][] = '_xxx__outer')) { function _xxx__outer($_l, $_args) { extract($_args); $_control->validateControl('outer')
 ;$iterations = 0; foreach (array(1,2,3) as $id): ?>
-<div id="<?php echo $_dynSnippetId = $_control->getSnippetId("inner-$id") ?>"><?php ob_start() ?>
+<div id="<?php echo $_control->getSnippetId("inner-$id") ?>"><?php ob_start() ?>
 				#<?php echo Nette\Templating\Helpers::escapeHtml($id, ENT_NOQUOTES) ?>
 
-<?php $_dynSnippets[$_dynSnippetId] = ob_get_flush() ?>
+<?php $_dynSnippets["inner-$id"] = ob_get_flush() ?>
 </div>
 <?php $iterations++; endforeach ?>
 	<?php if (isset($_dynSnippets)) return $_dynSnippets;


### PR DESCRIPTION
```
{snippet container}
    {foreach [1, 2, 3] as $id}
        {snippet dynamic-$id} ... {/snippet}
    {/foreach}
{/snippet}
```

Now, you have to invalidate only static snippet `container`. With my alteration, you have to invalidate both static snippet and dynamic snippet - and only dynamic snippet is put to payload. I believe it's the ussual desired behavior. Also, when you invalidate only static snippet, it adds all dynamic snippets as one item to payload (simply whole content of static snippet).

Example:

``` php
$this->invalidateControl('container');
$this->invalidateControl('dynamic-2');
```

results to `payload`:

``` js
{
    snippets: {
        'snippet--dynamic-2': ...
    }
}
```
