### PR TITLE
Dynamic snippets: invalidateControl() takes ID of snippet

### DIFF
--- a/Nette/Application/UI/Control.php
+++ b/Nette/Application/UI/Control.php
@@ -135,11 +135,19 @@ abstract class Control extends PresenterComponent implements IRenderable
 	/**
 	 * Forces control or its snippet to repaint.
 	 * @param  string
+	 * @param  array|mixed
 	 * @return void
 	 */
-	public function invalidateControl($snippet = NULL)
+	public function invalidateControl($snippet = NULL, $ids = array())
 	{
+		if (!is_array($ids)) {
+			$ids = func_get_args();
+			array_shift($ids);
+		}
 		$this->invalidSnippets[$snippet] = TRUE;
+		foreach ($ids as $id) {
+			$this->invalidSnippets[$snippet . '-' . $id] = TRUE;
+		}
 	}
 
 


### PR DESCRIPTION
It's just a shortcut:

```php
$this->invalidateControl('ratings');
$this->invalidateControl('ratings-'.$id);
```

becomes:

```php
$this->invalidateControl('ratings', $id);
```

It makes working with dynamic snippets much more comfortable, at least to me :)