### PR TITLE
Custom paths can be configured as collapsed in bluescreen

### DIFF
--- a/Nette/Diagnostics/BlueScreen.php
+++ b/Nette/Diagnostics/BlueScreen.php
@@ -23,9 +23,17 @@ use Nette;
  */
 class BlueScreen extends Nette\Object
 {
+	/** @var array Path to be collapsed in stack trace (e.g. core libraries) */
+	public $collapsePaths = array();
+
 	/** @var array */
 	private $panels = array();
 
+
+	public function __construct()
+	{
+		$this->collapsePaths[] = NETTE_DIR . DIRECTORY_SEPARATOR; // . 'Utils' . DIRECTORY_SEPARATOR . 'Object';
+	}
 
 
 	/**

--- a/Nette/Diagnostics/Helpers.php
+++ b/Nette/Diagnostics/Helpers.php
@@ -219,4 +219,19 @@ final class Helpers
 		}
 	}
 
+
+	/**
+	 * Should a file be collapsed in stack trace?
+	 * @param BlueScreen
+	 * @param string
+	 * @return bool
+	 */
+	public static function isCollapsed(BlueScreen $bluescreen, $file)
+	{
+		foreach($bluescreen->collapsePaths as $collapsePath) {
+			if(strpos($file, $collapsePath) === 0) return true;
+		}
+
+		return false;
+	}
 }

--- a/Nette/Diagnostics/templates/bluescreen.phtml
+++ b/Nette/Diagnostics/templates/bluescreen.phtml
@@ -40,7 +40,6 @@ static $errorTypes = array(
 
 $title = ($exception instanceof Nette\FatalErrorException && isset($errorTypes[$exception->getSeverity()])) ? $errorTypes[$exception->getSeverity()] : get_class($exception);
 
-$expandPath = NETTE_DIR . DIRECTORY_SEPARATOR; // . 'Utils' . DIRECTORY_SEPARATOR . 'Object';
 $counter = 0;
 
 ?><!DOCTYPE html><!-- "' --></script></style></pre></xmp></table>
@@ -323,9 +322,9 @@ $counter = 0;
 
 
 			<?php $stack = $ex->getTrace(); $expanded = NULL ?>
-			<?php if (strpos($ex->getFile(), $expandPath) === 0) {
+			<?php if (Helpers::isCollapsed($this, $ex->getFile()) ) {
 				foreach ($stack as $key => $row) {
-					if (isset($row['file']) && strpos($row['file'], $expandPath) !== 0) { $expanded = $key; break; }
+					if (isset($row['file']) && !Helpers::isCollapsed($this, $row['file'])) { $expanded = $key; break; }
 				}
 			} ?>
 

--- a/tests/Nette/Diagnostics/Bluescreen.collapsedPaths.phpt
+++ b/tests/Nette/Diagnostics/Bluescreen.collapsedPaths.phpt
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Test: Nette\Diagnostics\Debugger E_ERROR in console.
+ *
+ * @author     David Grudl
+ * @package    Nette\Diagnostics
+ * @subpackage UnitTests
+ */
+
+use Nette\Diagnostics\Debugger,
+	\Nette\Diagnostics\Helpers;
+
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+
+Debugger::$consoleMode = TRUE;
+Debugger::$productionMode = FALSE;
+
+Debugger::$blueScreen->collapsePaths[] = __DIR__;
+
+Assert::true(Helpers::isCollapsed(Debugger::$blueScreen, __FILE__));
+Assert::false(Helpers::isCollapsed(Debugger::$blueScreen, dirname(__DIR__) . '/somethingElse'));


### PR DESCRIPTION
Bluescreen can collapse Nette files when dumping a stack trace, but it is very useful to collapse other 3rd party libraries as well. Thus collapsing refactored.

Example of usage:
    Debugger::$blueScreen->collapsePaths[] = LIBS_DIR . '/PHPUnit';
