### PR TITLE
Database: bug in removeExtraTables for columns

### DIFF
--- a/Nette/Database/Table/Selection.php
+++ b/Nette/Database/Table/Selection.php
@@ -429,7 +429,7 @@ class Selection extends Nette\Object implements \Iterator, \ArrayAccess, \Counta
 
 		$prefix = $join ? "$this->delimitedName." : '';
 		if ($this->select) {
-			$cols = $this->removeExtraTables($this->tryDelimite(implode(', ', $this->select)));
+			$cols = $this->tryDelimite($this->removeExtraTables(implode(', ', $this->select)));
 
 		} elseif ($this->prevAccessed) {
 			$cols = $prefix . implode(', ' . $prefix, array_map(array($this->connection->getSupplementalDriver(), 'delimite'), array_keys($this->prevAccessed)));


### PR DESCRIPTION
Fixed bug in getSql method in Selection witch causes that when $selection->select('book.author.name') then removeExtraTables doesnt work becouse the string is already delimited
