### PR TITLE
Diagnostics\Bar: fixed HTML code for panel if throws Exception

### DIFF
--- a/Nette/Diagnostics/Bar.php
+++ b/Nette/Diagnostics/Bar.php
@@ -64,10 +64,11 @@ class Bar extends Nette\Object
 					'panel' => $tab ? (string) $panel->getPanel() : NULL,
 				);
 			} catch (\Exception $e) {
+				$html = nl2br(htmlSpecialChars((string) $e));
 				$panels[] = array(
-					'id' => "error-$id",
-					'tab' => "Error: $id",
-					'panel' => nl2br(htmlSpecialChars((string) $e)),
+					'id' => "error-" . preg_replace('#[^a-z0-9]+#i', '-', $id),
+					'tab' => "Error: ". preg_replace('#.+\\\\#A', '', $id),
+					'panel' => '<h1>Error: ' . $id . '</h1><div class="nette-inner">' . $html . '</div>',
 				);
 				while (ob_get_level() > $obLevel) { // restore ob-level if broken
 					ob_end_clean();


### PR DESCRIPTION
vysvětleno "zde":https://github.com/nette/nette/pull/488 ,akorát tam jsem to smazal. Prostě kód chyby se vypíše pěkně v okýnku jako ostatní panely.
