### PR TITLE
SafeStream: PHP Bug #47997 workaround [Closes #512]

### DIFF
--- a/Nette/Utils/SafeStream.php
+++ b/Nette/Utils/SafeStream.php
@@ -122,7 +122,7 @@ final class SafeStream
 		if ($mode === 'r+' || $mode[0] === 'a' || $mode[0] === 'c') {
 			$stat = fstat($this->handle);
 			fseek($this->handle, 0);
-			if (stream_copy_to_stream($this->handle, $this->tempHandle) !== $stat['size']) {
+			if ($stat['size'] !== 0 && stream_copy_to_stream($this->handle, $this->tempHandle) !== $stat['size']) {
 				$this->clean();
 				return FALSE;
 			}


### PR DESCRIPTION
Při použití safe streamu v režimu append a souboru s nulovou délkou (nebo neexistujícího) se uplatnil PHP Bug (https://bugs.php.net/bug.php?id=47997), resp. stream API "podivnost", kdy stream_copy_to_stream() vracela 1 i při nulové délce přenesených dat.
