### PR TITLE
Config: fixed annotations for nested containers

### DIFF
--- a/Nette/Config/Compiler.php
+++ b/Nette/Config/Compiler.php
@@ -176,7 +176,7 @@ class Compiler extends Nette\Object
 				$class->documents = preg_replace("#\S+(?= \\$$name$)#", $def->class, $class->documents);
 				$classes[] = $accessor = new Nette\Utils\PhpGenerator\ClassType($def->class);
 				foreach ($found as $item) {
-					$short = substr($item, strlen($name)  + 1);
+					$short = strtr(substr($item, strlen($name)  + 1), '.', '_');
 					$accessor->addDocument($defs[$item]->shared
 						? "@property {$defs[$item]->class} \$$short"
 						: "@method {$defs[$item]->class} create" . ucfirst("$short()"));


### PR DESCRIPTION
Instead of 

```
/**
 * @property Doctrine\ORM\Mapping\Driver\DriverChain $orm_defaultEntityManager_metadataDriver
 * @property Kdyby\Doctrine\Registry $registry
 */
class SystemContainer_doctrine { }
```

config was generated as

```
/**
 * @property Doctrine\ORM\Mapping\Driver\DriverChain $orm.defaultEntityManager.metadataDriver
 * @property Kdyby\Doctrine\Registry $registry
 */
class SystemContainer_doctrine { }
```
