### PR TITLE
Exception when Form::getHttpData() returns NULL

### DIFF
--- a/Nette/Forms/Controls/BaseControl.php
+++ b/Nette/Forms/Controls/BaseControl.php
@@ -342,8 +342,11 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 	 */
 	public function loadHttpData()
 	{
-		$path = explode('[', strtr(str_replace(array('[]', ']'), '', $this->getHtmlName()), '.', '_'));
-		$this->setValue(Nette\Utils\Arrays::get($this->getForm()->getHttpData(), $path, NULL));
+		$httpData = $this->getForm()->getHttpData();
+		if ($httpData !== NULL){
+			$path = explode('[', strtr(str_replace(array('[]', ']'), '', $this->getHtmlName()), '.', '_'));
+			$this->setValue(Nette\Utils\Arrays::get($httpData, $path, NULL));
+		}
 	}
 
 


### PR DESCRIPTION
I'm writting tests and I need to fake-submit the form, so I write something like

```
$form = new Nette\Application\UI\Form();
$send = $form->addSubmit('send');
$form->setSubmittedBy($send);
```

This results in error

```
Recoverable Error
Argument 1 passed to Nette\Utils\Arrays::get() must be an array, null given, called in .../Nette/Forms/Controls/BaseControl.php on line 344 and defined
```
