### PR TITLE
removed an invalid assertion 

### DIFF
--- a/Nette/Config/Extensions/NetteExtension.php
+++ b/Nette/Config/Extensions/NetteExtension.php
@@ -150,7 +150,6 @@ class NetteExtension extends Nette\Config\CompilerExtension
 		}
 		unset($config['expiration'], $config['autoStart'], $config['iAmUsingBadHost']);
 		if (!empty($config)) {
-			Validators::assertField($config, 'session', 'array');
 			$session->addSetup('setOptions', array($config));
 		}
 	}


### PR DESCRIPTION
It became invalid (and superflous) as a result of refactoring.
