### PR TITLE
User::isInRole() now works with array of IRole objects

### DIFF
--- a/Nette/Security/User.php
+++ b/Nette/Security/User.php
@@ -234,7 +234,9 @@ class User extends Nette\Object
 	 */
 	final public function isInRole($role)
 	{
-		return in_array($role, $this->getRoles(), TRUE);
+		return (bool) count(array_filter($this->getRoles(), function($value) use ($role) {
+				return ($value instanceof IRole) ? $value->getRoleId() == $role : $value == $role;
+		}));
 	}
 
 


### PR DESCRIPTION
Nyní User::isInRole() kontroluje pouze stringy, což mi přijde poněkud "omezující".

Současná situace:
Mějme dvě třídy, Identity (implemenující IIdentity) a Role (implementující IRole).
Třída Identity bude přes getter getRoles() načítat pole obsahující objekty s rolemi (Role).
Někde v aplikaci chci zkontrolovat, zda uživatel je v roli 'admin', tudíž zavolám $user->isInRole('admin'); -- nicméně tato metoda funguje pouze pro pole stringů, ale ne pro pole objektů implementujících IRole; což absolutně nedává smysl a ani to není nikde zmíněno, že by to fungovat nemělo.

Možná řešení:
1. Oddělat třetí parametr u in_array() a donutit třídy implementující IRole, aby měly metodu __toString() vracející název role
2. Přepsat metodu isInRole()
3. ???

Osobně jsem zvolil 2), protože mi přijde "hloupé" dávat zbytečné požadavky do kontraktu (co přesně by __toString() musel vracet) a není to BC break.
