### PR TITLE
Allow non-scalar parameters.

### DIFF
--- a/Nette/Application/Routers/Route.php
+++ b/Nette/Application/Routers/Route.php
@@ -309,7 +309,7 @@ class Route extends Nette\Object implements Application\IRouter
 				}
 			}
 
-			if (!is_scalar($params[$name]) && isset($meta['filterTable2'][$params[$name]])) {
+			if (is_scalar($params[$name]) && isset($meta['filterTable2'][$params[$name]])) {
 				$params[$name] = $meta['filterTable2'][$params[$name]];
 
 			} elseif (isset($meta['filterTable2']) && !empty($meta[self::FILTER_STRICT])) {


### PR DESCRIPTION
For example objects with __toString() method, but the filterOut function might work with anything.
