### PR TITLE
Forms: exportRules is protected

### DIFF
--- a/Nette/Forms/Controls/BaseControl.php
+++ b/Nette/Forms/Controls/BaseControl.php
@@ -531,7 +531,7 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 	/**
 	 * @return array
 	 */
-	private static function exportRules($rules)
+	protected static function exportRules($rules)
 	{
 		$payload = array();
 		foreach ($rules as $rule) {


### PR DESCRIPTION
exportRules potrebuji pouzit v podedenem formularovem prvku, ktery se generuje jinak, nez pres Nette\Utils\Html.
