### PR TITLE
FormMacros: better checkbox syntax for label macro

### DIFF
--- a/Nette/Latte/Macros/FormMacros.php
+++ b/Nette/Latte/Macros/FormMacros.php
@@ -60,7 +60,7 @@ class FormMacros extends MacroSet
 			$node->setArgs(substr($node->args, 0, -1));
 			return $writer->write($cmd);
 		} else {
-			return $writer->write($cmd . '->startTag()');
+			return $writer->write($cmd . '->startTag(); $label = $_label->getText()');
 		}
 	}
 


### PR DESCRIPTION
Support for syntax

```
 {form test}
    {label test}
        {input test}
        {$label}
    {/label}
 {/form}
```
