### PR TITLE
Latte: fixed macro {define}

### DIFF
--- a/Nette/Latte/Macros/UIMacros.php
+++ b/Nette/Latte/Macros/UIMacros.php
@@ -258,7 +258,7 @@ if (!empty($_control->snippetMode)) {
 				$node->closingCode .= "\n</$tag>";
 				return $writer->write("?>\n<$tag id=\"<?php echo \$_dynSnippetId = \$_control->getSnippetId({$writer->formatWord($name)}) ?>\"><?php ob_start()");
 
-			} else {
+			} elseif ($node->name !== 'define') {
 				$node->data->leave = TRUE;
 				$fname = $writer->formatWord($name);
 				$node->closingCode = "<?php }} call_user_func(reset(\$_l->blocks[$fname]), \$_l, get_defined_vars()) ?>";


### PR DESCRIPTION
Fixed macro <code>{define}</code>, that should, by it's name, only define macro, not output it.

```
{define #name}
   content
{/define}
```

Expected output? Nothig
