### PR TITLE
SMTP connection reset after successful TLS handshake, see RFC 2487

### DIFF
--- a/Nette/Mail/SmtpMailer.php
+++ b/Nette/Mail/SmtpMailer.php
@@ -129,6 +129,7 @@ class SmtpMailer extends Nette\Object implements IMailer
 			if (!stream_socket_enable_crypto($this->connection, TRUE, STREAM_CRYPTO_METHOD_TLS_CLIENT)) {
 				throw new SmtpException('Unable to connect via TLS.');
 			}
+			$this->write("EHLO $self", 250);
 		}
 
 		if ($this->username != NULL && $this->password != NULL) {


### PR DESCRIPTION
5.2 Result of the STARTTLS Command

Upon completion of the TLS handshake, the SMTP protocol is reset to the initial state (the state in SMTP after a server issues a 220 service ready greeting). The server MUST discard any knowledge obtained from the client, such as the argument to the EHLO command, which was not obtained from the TLS negotiation itself. The client MUST discard any knowledge obtained from the server, such as the list of SMTP service extensions, which was not obtained from the TLS negotiation itself. The client SHOULD send an EHLO command as the first command after a successful TLS negotiation.
