### PR TITLE
Find the topmost @layout even if your module is within an additional sub-directory

### DIFF
--- a/Nette/Application/UI/Presenter.php
+++ b/Nette/Application/UI/Presenter.php
@@ -516,7 +516,11 @@ abstract class Presenter extends Control implements Application\IPresenter
 			$list[] = "$dir/templates/@$layout.phtml";
 			$dir = dirname($dir);
 		} while ($dir && ($name = substr($name, 0, strrpos($name, ':'))));
-		return $list;
+
+		$list[] = APP_DIR."/templates/@$layout.latte";
+		$list[] = APP_DIR."/templates/@$layout.phtml";
+
+		return array_unique($list);
 	}
 
 


### PR DESCRIPTION
Here's my directory structure:
apps/AdminModule/SuperModule
apps/AdminModule/EditorModule
...

class Super_AdminUserPresenter extends Admin_BasePresenter

@layout.latte is only found if in
apps/AdminModule/SuperModule/template
apps/AdminModule/template
but not if it's in
apps/template

This pull request fixes it.

A better fix would probably traverse all directories, my solution works sort of as a safety net if locating the layout in "the usual places" fails.

Also, I realize that I could name my presenter Super_Admin_AdminUserPresenter which would make the existing code find the template even in apps/template. I believe however, that my directory structure is legit so why not have this method work with it too.
