### PR TITLE
Latte: fixed templates so that CompileExceptions have correct line number

### DIFF
--- a/Nette/Templating/Template.php
+++ b/Nette/Templating/Template.php
@@ -443,7 +443,12 @@ class Template extends Nette\Object implements ITemplate
 		$tokens = token_get_all($source);
 		foreach ($tokens as $n => $token) {
 			if (is_array($token)) {
-				if ($token[0] === T_INLINE_HTML || $token[0] === T_CLOSE_TAG) {
+				if ($token[0] === T_INLINE_HTML) {
+					$res .= $token[1];
+					continue;
+
+				} elseif ($token[0] === T_CLOSE_TAG) {
+					$res .= str_repeat("\n", substr_count($php, "\n")); // keep all the line breaks
 					$res .= $token[1];
 					continue;
 

--- a/tests/Nette/Latte/mixedCode.phpt
+++ b/tests/Nette/Latte/mixedCode.phpt
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Test: CompileExceptions have correct line number in mixed php/latte template
+ *
+ * @author     Jan Dolecek, David Grudl
+ * @package    Nette\Latte
+ * @subpackage UnitTests
+ * @keepTrailingSpaces
+ */
+
+use Nette\Latte,
+	Nette\Templating\FileTemplate;
+
+
+
+require __DIR__ . '/../bootstrap.php';
+
+require __DIR__ . '/Template.inc';
+
+
+
+$template = new FileTemplate(__DIR__ . '/templates/mixedCode.latte');
+$template->registerFilter(new Latte\Engine);
+
+try {
+	$template->compile();
+} catch(\Nette\Latte\CompileException $e) {
+	Assert::same(4, $e->sourceLine);
+	Assert::same("Unknown macro {notDefined}", $e->getMessage());
+}

--- a/tests/Nette/Latte/templates/mixedCode.latte
+++ b/tests/Nette/Latte/templates/mixedCode.latte
@@ -1,0 +1,4 @@
+<?php
+ // php block
+?>
+{notDefined line 4}


### PR DESCRIPTION
... in mixed php/latte template

At the moment, php blocks within template are removed before compiling Latte, which results into incorrect line numbers in CompileException's. Thus, Debugger highlights wrong line.
