### PR TITLE
AutoLoader: prepend in registration

### DIFF
--- a/Nette/Loaders/AutoLoader.php
+++ b/Nette/Loaders/AutoLoader.php
@@ -59,15 +59,16 @@ abstract class AutoLoader extends Nette\Object
 
 	/**
 	 * Register autoloader.
+	 * @param  bool  prepend autoloader? (default FALSE -> append)
 	 * @return void
 	 */
-	public function register()
+	public function register($prepend = FALSE)
 	{
 		if (!function_exists('spl_autoload_register')) {
 			throw new Nette\NotSupportedException('spl_autoload does not exist in this PHP installation.');
 		}
 
-		spl_autoload_register(array($this, 'tryLoad'));
+		spl_autoload_register(array($this, 'tryLoad'), TRUE, (bool) $prepend);
 		self::$loaders[spl_object_hash($this)] = $this;
 	}
 


### PR DESCRIPTION
Myslím, že by bylo dobré, aby člověk mohl rozhodnout v jakém pořadí se budou volat autoloadery. Hodí se to teoreticky jak pro použití s RobotLoaderem a hlavně pak pokud píše člověk vlastní autoloader, který chce v rámci konzistence aplikace podědit také od AutoLoaderu z Nette.
