### PR TITLE
RobotLoader: fix strict interface warning

### DIFF
--- a/Nette/Loaders/RobotLoader.php
+++ b/Nette/Loaders/RobotLoader.php
@@ -71,12 +71,13 @@ class RobotLoader extends AutoLoader
 
 	/**
 	 * Register autoloader.
+	 * @param  bool  prepend autoloader?
 	 * @return RobotLoader  provides a fluent interface
 	 */
-	public function register()
+	public function register(/**/$prepend = FALSE/**/)
 	{
 		$this->list = $this->getCache()->load($this->getKey(), callback($this, '_rebuildCallback'));
-		parent::register();
+		parent::register(/**/$prepend/**/);
 		return $this;
 	}
 


### PR DESCRIPTION
Davide moc se omlouvám, ale v pull requestu ohledně AutoLoaderu (https://github.com/nette/nette/pull/616), který si už začlenil byla chybka - nedodržení striktního rozhraní RobotLoaderu, což jsme v místě, kde jsem kód upravoval, přehlédl. Přikládám opravu a teď už by to snad mělo být v pořádku. Je hloupé, že se na tohle moc dobře nedají psát testy a snadno se tak něco přehlédne :(
