### PR TITLE
Debugger: use colors in dump only if terminal supports it

### DIFF
--- a/Nette/Diagnostics/Debugger.php
+++ b/Nette/Diagnostics/Debugger.php
@@ -606,7 +606,7 @@ final class Debugger
 		}
 
 		if (self::$consoleMode) {
-			if (self::$consoleColors && substr(PHP_OS, 0, 3) !== 'WIN') {
+			if (self::$consoleColors && preg_match('~xterm~A', getenv('TERM'))) {
 				$output = preg_replace_callback('#<span class="php-(\w+)">|</span>#', function($m) {
 					return "\033[" . (isset($m[1], Debugger::$consoleColors[$m[1]]) ? Debugger::$consoleColors[$m[1]] : '0') . "m";
 				}, $output);


### PR DESCRIPTION
Some terminals **don't** support colors even on linux (e.g. built-in terminal in PhpStorm) and then we see very ugly mess of characters. It's better to check against terminal type being used, which is mostly _xterm_ or _xterm-something_ (like _xterm-256color_).

When no terminal info is given (on windows or in PhpStorm's build-in terminal), getenv returns false which suppresses colors.
