### PR TITLE
Config: fixed after refactoring

### DIFF
--- a/Nette/Config/Extensions/NetteExtension.php
+++ b/Nette/Config/Extensions/NetteExtension.php
@@ -236,7 +236,6 @@ class NetteExtension extends Nette\Config\CompilerExtension
 			$container->addDefinition($this->prefix('mailer'))
 				->setClass('Nette\Mail\SendmailMailer');
 		} else {
-			Validators::assertField($config, 'mailer', 'array');
 			$container->addDefinition($this->prefix('mailer'))
 				->setClass('Nette\Mail\SmtpMailer', array($config));
 		}


### PR DESCRIPTION
Broken in 2a741cac, because _setupMailer_ already receives just one section of the config: https://github.com/nette/nette/commit/2a741cac#L0R93
