### PR TITLE
SelectBox: Respect prompt when setting items.

### DIFF
--- a/Nette/Forms/Controls/SelectBox.php
+++ b/Nette/Forms/Controls/SelectBox.php
@@ -156,8 +156,8 @@ class SelectBox extends BaseControl
 	 */
 	public function setItems(array $items, $useKeys = TRUE)
 	{
-		$this->items = $items;
-		$this->allowed = array();
+		$this->items = $this->prompt === TRUE ? array('' => $this->items['']) + $items : $items;
+		$this->allowed = $this->prompt === TRUE ? array('' => '') : array();
 		$this->useKeys = (bool) $useKeys;
 
 		foreach ($items as $key => $value) {


### PR DESCRIPTION
Currently SelectBox ignores prompt if it was set before setting items.
This commit ensures that prompt is no longer ignored. (See the [forum thread](http://forum.nette.org/cs/10704-setprompt-volany-pred-setitems-nefunguje))

However, it's not entirely clear whether this is a bug or a feature.
- On one hand, it seems logical to leave the prompt as set.
- On the other hand, it also seems logical to "reset" the prompt when new set of items is added.
