### PR TITLE
Config/Configurator: Improved detectDebugMode

### DIFF
--- a/Nette/Config/Configurator.php
+++ b/Nette/Config/Configurator.php
@@ -307,6 +307,10 @@ class Configurator extends Nette\Object
 	 */
 	public static function detectDebugMode($list = NULL)
 	{
+		if (isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+			return FALSE;
+		}
+
 		$list = is_string($list) ? preg_split('#[,\s]+#', $list) : $list;
 		$list[] = '127.0.0.1';
 		$list[] = '::1';

--- a/tests/Nette/Config/Configurator.productionMode.phpt
+++ b/tests/Nette/Config/Configurator.productionMode.phpt
@@ -33,3 +33,7 @@ Assert::true( $configurator->isDebugMode() );
 
 $configurator->setDebugMode(array(php_uname('n')));
 Assert::true( $configurator->isDebugMode() );
+
+$_SERVER['HTTP_X_FORWARDED_FOR'] = '127.0.0.1';
+Assert::false( $configurator::detectDebugMode() );
+unset($_SERVER['HTTP_X_FORWARDED_FOR']);


### PR DESCRIPTION
Servers running Varnish cache with default settings are mistakenly detected as a local environment and therefore debug mode is enabled.
Varnish passes HTTP header HTTP_X_FORWARDED_FOR and this could be used to detect Varnish installation. (see https://www.varnish-cache.org/docs/3.0/faq/http.html or default.vcl in Varnish files)
Only possible problem I can see is falling into safer non-debug state.
