### PR TITLE
dumpPhp: Fix for a bug in dumping associative arrays with numerical keys that are out of order

### DIFF
--- a/tests/Test/Assert.php
+++ b/tests/Test/Assert.php
@@ -406,7 +406,7 @@ class Assert
 				foreach ($var as $k => &$v) {
 					if ($k !== $marker) {
 						$s .= "$space\t" . ($k === $counter ? '' : self::dumpPhp($k) . " => ") . self::dumpPhp($v, $level + 1) . ",\n";
-						$counter = is_int($k) ? $k + 1 : $counter;
+						$counter = is_int($k) ? max($k + 1, $counter) : $counter;
 					}
 				}
 				unset($var[$marker]);


### PR DESCRIPTION
Example of an array that would be dumped with wrong keys:

```
$myarray = array(
  9 => array('9'),
  2 => array('2'),
  3 => array('3'),
);
```

It would be dumped as

```
array(
    9 => array(
        '9',
    ),
    2 => array(
        '2',
    ),
    array(
        '3',
    ),
)
```

The error is in the last key - this definition would assign 10 to the last key.

```
var_export(array(
    9 => array(
        '9',
    ),
    2 => array(
        '2',
    ),
    array(
        '3',
    ),
));
```

gives:

```
array (
  9 => 
  array (
    0 => '9',
  ),
  2 => 
  array (
    0 => '2',
  ),
  10 => 
  array (
    0 => '3',
  ),
)
```
