### PR TITLE
Latte: smart removal of whitespace around comments

### DIFF
--- a/Nette/Latte/Compiler.php
+++ b/Nette/Latte/Compiler.php
@@ -137,6 +137,9 @@ class Compiler extends Nette\Object
 
 				} elseif ($token->type === Token::HTML_ATTRIBUTE) {
 					$this->processHtmlAttribute($token);
+
+				} elseif ($token->type === Token::COMMENT) {
+					$this->processComment($token);
 				}
 			}
 		} catch (CompileException $e) {
@@ -349,6 +352,15 @@ class Compiler extends Nette\Object
 		}
 	}
 
+
+
+	private function processComment(Token $token)
+	{
+		$isLeftmost = trim(substr($this->output, strrpos("\n$this->output", "\n"))) === '';
+		if (!$isLeftmost) {
+			$this->output .= substr($token->text, strlen(rtrim($token->text)));
+		}
+	}
 
 
 	/********************* macros ****************d*g**/

--- a/tests/Nette/Latte/macros.whitespace.2.phpt
+++ b/tests/Nette/Latte/macros.whitespace.2.phpt
@@ -99,3 +99,25 @@ qwerty
 
 EOD
 ));
+
+
+Assert::match(<<<EOD
+line 1
+line 2
+EOD
+
+, (string) $template->setSource(<<<EOD
+line 1 {* comment *}
+line 2
+EOD
+));
+
+
+Assert::match(<<<EOD
+word 1  word 2
+EOD
+
+, (string) $template->setSource(<<<EOD
+word 1 {* comment *} word 2
+EOD
+));


### PR DESCRIPTION
If comment is on a line with some other code, whitespace after it won't be trimmed.

(reported here: http://forum.nette.org/cs/10896-komentare-v-latte-a-inteligentni-odstranovani-whitespace)
