### PR TITLE
Database: static reflection and reflection chain

### DIFF
--- a/Nette/Database/Reflection/ReflectionChain.php
+++ b/Nette/Database/Reflection/ReflectionChain.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (http://nette.org)
+ *
+ * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
+ *
+ * For the full copyright and license information, please view
+ * the file license.txt that was distributed with this source code.
+ */
+
+namespace Nette\Database\Reflection;
+
+use Nette;
+
+
+
+/**
+ * Chain multiple reflections, trying them one by one until it gets a result
+ *
+ * @author     Jan Dolecek
+ * @property-write Nette\Database\Connection $connection
+ */
+class ReflectionChain extends Nette\Object implements Nette\Database\IReflection
+{
+	/** @var Nette\Database\IReflection */
+	protected $reflections = array();
+
+
+
+	/**
+	 * Add new database reflection to chain
+	 * @param bool To be used as first one? Otherwise last one.
+	 */
+	public function addReflection(\Nette\Database\IReflection $reflection, $first = FALSE)
+	{
+		if ($first) {
+			array_unshift($this->reflections, $reflection);
+		} else {
+			$this->reflections[] = $reflection;
+		}
+	}
+
+
+
+	public function setConnection(Nette\Database\Connection $connection)
+	{}
+
+
+
+	public function getPrimary($table)
+	{
+		return $this->chainMethod(__FUNCTION__, func_get_args());
+	}
+
+
+
+	public function getHasManyReference($table, $key)
+	{
+		return $this->chainMethod(__FUNCTION__, func_get_args());
+	}
+
+
+
+	public function getBelongsToReference($table, $key)
+	{
+		return $this->chainMethod(__FUNCTION__, func_get_args());
+	}
+
+
+
+	private function chainMethod($method, $args)
+	{
+		foreach ($this->reflections as $reflection) {
+			try {
+				$ret = call_user_func_array(array($reflection, $method), $args);
+				if ($ret !== NULL) {
+					return $ret;
+				}
+			} catch(\PDOException $e) {
+			}
+		}
+	}
+
+}

--- a/Nette/Database/Reflection/StaticReflection.php
+++ b/Nette/Database/Reflection/StaticReflection.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (http://nette.org)
+ *
+ * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
+ *
+ * For the full copyright and license information, please view
+ * the file license.txt that was distributed with this source code.
+ */
+
+namespace Nette\Database\Reflection;
+
+use Nette;
+
+
+
+/**
+ * Statically configured reflection
+ *
+ * @author     Jan Dolecek
+ * @property-write Nette\Database\Connection $connection
+ */
+class StaticReflection extends Nette\Object implements Nette\Database\IReflection
+{
+	/** @var array For each table: { primary, hasMany, belongsTo } */
+	public $structure;
+
+
+
+	/**
+	 * @param array database structure
+	 */
+	public function __construct(array $structure = NULL)
+	{
+		$this->structure = $structure;
+	}
+
+
+
+	public function setConnection(Nette\Database\Connection $connection)
+	{
+	}
+
+
+
+	public function getPrimary($table)
+	{
+		if (isset($this->structure[$table]['primary'])) {
+			return $this->structure[$table]['primary'];
+		}
+	}
+
+
+
+	public function getHasManyReference($table, $key)
+	{
+		if (isset($this->structure[$table]['hasMany'][$key])) {
+			return $this->structure[$table]['hasMany'][$key];
+		}
+	}
+
+
+
+	public function getBelongsToReference($table, $key)
+	{
+		if (isset($this->structure[$table]['belongsTo'][$key])) {
+			return $this->structure[$table]['belongsTo'][$key];
+		}
+	}
+
+}

--- a/tests/Nette/Database/ReflectionChain.phpt
+++ b/tests/Nette/Database/ReflectionChain.phpt
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Test: Nette\Database\Connection: chain static and MySQL reflection
+ *
+ * @author     Jan Dolecek
+ * @package    Nette\Database
+ * @subpackage UnitTests
+ */
+
+require __DIR__ . '/connect.inc.php'; // create $connection
+
+Nette\Database\Helpers::loadFromFile($connection, __DIR__ . '/nette_test1.sql');
+
+
+
+$neon = Nette\Utils\Neon::decode(file_get_contents(__DIR__ . '/StaticReflection.neon'));
+$reflection1 = new Nette\Database\Reflection\StaticReflection($neon['simple']);
+
+$reflection2 = new Nette\Database\Reflection\DiscoveredReflection;
+$reflection2->setConnection($connection);
+
+$chain = new Nette\Database\Reflection\ReflectionChain;
+$chain->addReflection($reflection1);
+$chain->addReflection($reflection2);
+
+$connection->setDatabaseReflection($chain);
+
+
+
+$jakub = $connection->table('author')->get(11);
+$book = $jakub->related('book')->fetch();
+Assert::same( 1, $book->id );
+Assert::same( 'Jakub Vrana', $book->author->name );  // uses DiscoveredReflection
+Assert::same( 'Jakub Vrana', $book->author2->name ); // uses StaticReflection
+Assert::same( 'Jakub Vrana', $book->translator->name );

--- a/tests/Nette/Database/StaticReflection.neon
+++ b/tests/Nette/Database/StaticReflection.neon
@@ -1,0 +1,34 @@
+# full reflection of DB
+database:
+	author:
+		primary: id
+		hasMany:
+			book: [ book, author_id ]
+
+	book:
+		primary: id
+		hasMany:
+			book_tag: [ book, book_id ]
+
+		belongsTo:
+			author: [ author, author_id ]
+			translator: [ author, translator_id ]
+
+	tag:
+		primary: id
+		hasMany:
+			book_tag: [ book_tag, tag_id ]
+
+	book_tag:
+		primary: NULL
+		belongsTo:
+			tag: [ tag, tag_id ]
+			book: [ book, book_id ]
+
+
+# just small part, to be chained
+simple:
+	book:
+		belongsTo:
+			author2: [ author, author_id ]
+			translator: [ author, translator_id ]

--- a/tests/Nette/Database/StaticReflection.phpt
+++ b/tests/Nette/Database/StaticReflection.phpt
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Test: Nette\Database\Connection: static reflection
+ *
+ * @author     Jan Dolecek
+ * @package    Nette\Database
+ * @subpackage UnitTests
+ */
+
+require __DIR__ . '/connect.inc.php'; // create $connection
+
+Nette\Database\Helpers::loadFromFile($connection, __DIR__ . '/nette_test1.sql');
+
+
+
+$neon = Nette\Utils\Neon::decode(file_get_contents(__DIR__ . '/StaticReflection.neon'));
+$reflection = new Nette\Database\Reflection\StaticReflection($neon['database']);
+$connection->setDatabaseReflection($reflection);
+
+
+
+Assert::same( 'id', $reflection->getPrimary('author') );
+Assert::same( NULL, $reflection->getPrimary('book_tag') );
+
+
+
+$jakub = $connection->table('author')->get(11);
+Assert::same( 'Jakub Vrana', $jakub->name );
+
+
+
+$book = $jakub->related('book')->fetch();
+Assert::same( 1, $book->id );
+Assert::same( 'Jakub Vrana', $book->author->name );
+Assert::same( 'Jakub Vrana', $book->translator->name );


### PR DESCRIPTION
Sometimes I can not use _DiscoveredReflection_, e.g. because of MyISAM tables. Therefore I'd like to configure reflection manually (see neon config in tests).

But I don't wanna configure it all manually, thus I'd _chain_ the two reflections by `ReflectionChain` (again, example in tests)
