### PR TITLE
Forms\SelectBox: setItems() can be called after setPrompt()

### DIFF
--- a/Nette/Forms/Controls/SelectBox.php
+++ b/Nette/Forms/Controls/SelectBox.php
@@ -33,7 +33,7 @@ class SelectBox extends BaseControl
 	/** @var array */
 	protected $allowed = array();
 
-	/** @var bool */
+	/** @var mixed */
 	private $prompt = FALSE;
 
 	/** @var bool */
@@ -104,14 +104,10 @@ class SelectBox extends BaseControl
 	 */
 	public function setPrompt($prompt)
 	{
-		if (is_bool($prompt)) {
-			$this->prompt = $prompt;
-		} else {
-			$this->prompt = TRUE;
-			if ($prompt !== NULL) {
-				$this->items = array('' => $prompt) + $this->items;
-				$this->allowed = array('' => '') + $this->allowed;
-			}
+		$this->prompt = $prompt;
+		if ($prompt !== NULL && !is_bool($prompt)) {
+			$this->items = array('' => $prompt) + $this->items;
+			$this->allowed = array('' => '') + $this->allowed;
 		}
 		return $this;
 	}
@@ -156,8 +152,11 @@ class SelectBox extends BaseControl
 	 */
 	public function setItems(array $items, $useKeys = TRUE)
 	{
-		$this->items = $this->prompt === TRUE ? array('' => $this->items['']) + $items : $items;
-		$this->allowed = $this->prompt === TRUE ? array('' => '') : array();
+		$this->items = $items;
+		if ($this->prompt) {
+			$this->items = array('' => is_bool($this->prompt) ? $this->items[''] : $this->prompt) + $this->items;
+		}
+		$this->allowed = $this->prompt ? array('' => '') : array();
 		$this->useKeys = (bool) $useKeys;
 
 		foreach ($items as $key => $value) {

--- a/tests/Nette/Forms/Forms.example.001.expect
+++ b/tests/Nette/Forms/Forms.example.001.expect
@@ -72,6 +72,12 @@
 
 	<td><select name="country" id="frm-country" data-nette-rules="{op:':equal',rules:[{op:':filled',msg:'Select your country'}],control:'send',arg:true}" data-nette-empty-value=""><option value="" selected="selected">Select your country</option><optgroup label="Europe"><option value="CZ">Czech Republic</option><option value="SK">Slovakia</option><option value="GB">United Kingdom</option></optgroup><option value="CA">Canada</option><option value="US">United States</option><option value="?">other</option></select></td>
 </tr>
+
+<tr>
+	<th><label for="frm-countrySetItems">Country:</label></th>
+
+	<td><select name="countrySetItems" id="frm-countrySetItems" data-nette-empty-value=""><option value="" selected="selected">Select your country</option><optgroup label="Europe"><option value="CZ">Czech Republic</option><option value="SK">Slovakia</option><option value="GB">United Kingdom</option></optgroup><option value="CA">Canada</option><option value="US">United States</option><option value="?">other</option></select></td>
+</tr>
 </table>
 </div>
 </fieldset>

--- a/tests/Nette/Forms/Forms.example.001.phpt
+++ b/tests/Nette/Forms/Forms.example.001.phpt
@@ -86,6 +86,10 @@ $form->addSelect('country', 'Country:', $countries)
 	->addConditionOn($form['send'], Form::EQUAL, TRUE)
 		->addRule(Form::FILLED, 'Select your country');
 
+$form->addSelect('countrySetItems', 'Country:')
+	->setPrompt('Select your country')
+	->setItems($countries);
+
 
 // group Your account
 $form->addGroup('Your account');


### PR DESCRIPTION
I updated first test for forms, but of course I can provide ninth :)

I expect to be free to call these methods in any possible order, otherwise I wouldn't want to write according note to the documentation :)
