### PR TITLE
Database: Selection::insert() creates rows using createRow()

### DIFF
--- a/Nette/Database/Table/Selection.php
+++ b/Nette/Database/Table/Selection.php
@@ -640,10 +640,10 @@ class Selection extends Nette\Object implements \Iterator, \ArrayAccess, \Counta
 
 		if (!isset($data[$this->primary]) && ($id = $this->connection->lastInsertId())) {
 			$data[$this->primary] = $id;
-			return $this->rows[$id] = new ActiveRow($data, $this);
+			return $this->rows[$id] = $this->createRow($data);
 
 		} else {
-			return new ActiveRow($data, $this);
+			return $this->createRow($data);
 
 		}
 	}


### PR DESCRIPTION
I want to use my own ActiveRow class. After this change I can easily do it by overwriting the createRow() method.
