### PR TITLE
Configurator, Debbuger: Added default possibility to turn off the debug mode from console.

### DIFF
--- a/Nette/Config/Configurator.php
+++ b/Nette/Config/Configurator.php
@@ -307,7 +307,7 @@ class Configurator extends Nette\Object
 	 */
 	public static function detectDebugMode($list = NULL)
 	{
-		if (PHP_SAPI === 'cli' && in_array('no-debug', $_SERVER['argv'])) {
+		if (PHP_SAPI === 'cli' && in_array('--no-debug', $_SERVER['argv'])) {
 			return FALSE;
 		}
 

--- a/Nette/Diagnostics/Debugger.php
+++ b/Nette/Diagnostics/Debugger.php
@@ -230,7 +230,7 @@ final class Debugger
 		if (is_bool($mode)) {
 			self::$productionMode = $mode;
 
-		} elseif (self::$consoleMode && in_array('no-debug', $_SERVER['argv'])) {
+		} elseif (self::$consoleMode && in_array('--no-debug', $_SERVER['argv'])) {
 			self::$productionMode = TRUE;
 
 		} elseif ($mode !== self::DETECT || self::$productionMode === NULL) { // IP addresses or computer names whitelist detection


### PR DESCRIPTION
I think there could be some default possibility to force the production mode when running the application from console.

No BC breaks, simply: only when there is the 'no-debug' parameter in the console, the production mode is forced.
