### PR TITLE
Image button coordinates set as value when available

### DIFF
--- a/Nette/Forms/Controls/ImageButton.php
+++ b/Nette/Forms/Controls/ImageButton.php
@@ -38,6 +38,25 @@ class ImageButton extends SubmitButton
 
 
 	/**
+	 * Sets coordinates as a value if available
+	 * @param  bool|array
+	 * @return ImageButton  provides a fluent interface
+	 */
+	public function setValue($value)
+	{
+		if (is_array($value) && count($value)) {
+			$this->value = $value;
+			$this->getForm()->setSubmittedBy($this);
+			return $this;
+
+		} else {
+			return parent::setValue($value);
+		}
+	}
+
+
+
+	/**
 	 * Returns HTML name of control.
 	 * @return string
 	 */


### PR DESCRIPTION
As you can see [here](http://api.nette.org/2.0/source-Forms.Controls.ImageButton.php.html#44), there's a different way in which Nette deals with image button when it's attached to a form container:

``` php
<?php
$form->addImage('test'); // <input name="test" ...
$form->addContainer('cont')->addImage('test'); // <input name="cont[test][]" ...
```

Which causes that in the HTTP request we get the value of that button as an array of coordinates, which is unfortunately [thrown away](http://api.nette.org/2.0/source-Forms.Controls.SubmitButton.php.html#55) without any use.

So basically what I'm trying to accomplish in my commit is to inherit the setValue() method in ImageButton class so that you can then get the coordinates:

``` php
<?php
function processForm(UI\Form $form)
{
    dump($form['cont']['test']->value); // array( coord_x, coord_y )
}
```

It means that if we need the coordinates for some reason, we'll have to attach the image button to some container.
