### PR TITLE
Tests: UI\Presenter::storeRequest()

### DIFF
--- a/tests/Nette/Application.UI/Presenter.storeRequest().phpt
+++ b/tests/Nette/Application.UI/Presenter.storeRequest().phpt
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * Test: Nette\Application\UI\Presenter::storeRequest()
+ *
+ * @author     Matěj Koubík
+ * @package    Nette\Application\UI
+ * @subpackage UnitTests
+ */
+
+use Nette\Http,
+	Nette\Application,
+	Nette\DI,
+	Nette\Security;
+
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+
+class TestPresenter extends Application\UI\Presenter
+{
+	public function sendTemplate($value='') {}
+}
+
+class MockSession extends Http\Session
+{
+	public $testSection;
+
+	public function __construct() {}
+
+	public function getSection($section, $class = 'Nette\Http\SessionSection')
+	{
+		return $this->testSection;
+	}
+}
+
+class MockSessionSection extends Nette\Object implements \ArrayAccess
+{
+	public $testedKeyExistence;
+	public $storedKey;
+	public $storedValue;
+	public $testExpiration;
+	public $testExpirationVariables;
+
+	public function __isset($name)
+	{
+		$this->testedKeyExistence = $name;
+		return false;
+	}
+
+	public function __set($name, $value)
+	{
+		$this->storedKey = $name;
+		$this->storedValue = $value;
+	}
+
+	public function setExpiration($expiraton, $variables = NULL)
+	{
+		$this->testExpiration = $expiraton;
+		$this->testExpirationVariables = $variables;
+	}
+
+	public function offsetExists($name)
+	{
+		return $this->__isset($name);
+	}
+
+	public function offsetSet($name, $value)
+	{
+		$this->__set($name, $value);
+	}
+
+	public function offsetGet($name) {}
+	public function offsetUnset($name) {}
+}
+
+class MockUser extends Security\User
+{
+	public function __construct() {}
+
+	public function getId()
+	{
+		return 'test_id';
+	}
+}
+
+class MockApplication extends Application\Application
+{
+	public function __construct() {}
+}
+
+class MockHttpContext extends Http\Context
+{
+	public function __construct() {}
+}
+
+class MockHttpRequest extends Http\Request
+{
+	public function __construct() {}
+}
+
+
+$context = new DI\Container();
+$application = new MockApplication();
+$httpContext = new MockHttpContext();
+$httpRequest = new MockHttpRequest();
+$httpResponse = new Http\Response();
+$session = new MockSession();
+$section = $session->testSection = new MockSessionSection($session);
+$user = new MockUser();
+$applicationRequest = new Application\Request('', '', array());
+
+$presenter = new TestPresenter();
+$presenter->injectPrimary($context, $application, $httpContext, $httpRequest, $httpResponse, $session, $user);
+$presenter->run($applicationRequest);
+
+$expiration = '+1 year';
+$key = $presenter->storeRequest($expiration);
+
+Assert::equal($expiration, $section->testExpiration);
+Assert::equal($key, $section->testExpirationVariables);
+Assert::equal($key, $section->testedKeyExistence);
+Assert::equal($key, $section->storedKey);
+Assert::same(array($user->getId(), $applicationRequest), $section->storedValue);


### PR DESCRIPTION
Tohle není ani tak pull request, jako spíš námět k diskusi. Procházel jsem si třídu Presenter abych zjistil co všechno vlastně dělá a jak by se to dalo rozložit a všimnul jsem si, že nemá skoro žádné testy. Podle mě by bylo dobré před jakoukoliv manipulací s touhle třídou ty testy doplnit, aby měl presenter jasně definovaný kontrakt minimálně vůči samotnému frameworku. Tak jsem prošel zdrojáky nette abych zjistil kde všude a jak se presenter používá a případně na to dopsal testy.

Přemýšlel jsem proč tam asi ty testy nejsou a napadlo mě několik vysvětlení:
- Presenter je tězko testovatelný: To už po "odstranění" závislosti na DI\Container není pravda. Nicméně v injectPrimary() můsím předávat (a tudíž mockovat) i závislosti které v testu nepotřebuju. Možná pokud by tam byly settery a ty se používaly v injectPrimary()...
- Celé "se to bude" předělávat a proto nemá cenu psát testy na starý kód: S tím bych nesouhlasil - i když se při refactoringu budou muset některé testy přepisovat, aspoň bude v commitu vidět, jak se změnilo chování presenteru nebo tříd které z něj vzejdou.
- Nikdo prostě ty testy nenapsal: Pokud to tak je, tak bych klidně nějaké napsal, <del>až se zase budu nudit</del> až budu mít zase před deadlinem a před příjmačkama a budu prokrastinovat.

Tohle je zatím taková první vlaštovka, byl bych rád kdyby to někdo zkouknul, jestli se ty testy vůbec takhle píšou, jestli to nemám blbě, jestli tam nemám nějaké zbytečné mock třídy apod.
