### PR TITLE
Check unknown config sections after calling 'loadConfiguration'

### DIFF
--- a/Nette/Config/Compiler.php
+++ b/Nette/Config/Compiler.php
@@ -113,13 +113,13 @@ class Compiler extends Nette\Object
 
 	public function processExtensions()
 	{
+		foreach ($this->extensions as $name => $extension) {
+			$extension->loadConfiguration();
+		}
+
 		if ($extra = array_diff_key($this->config, self::$reserved, $this->extensions)) {
 			$extra = implode("', '", array_keys($extra));
 			throw new Nette\InvalidStateException("Found sections '$extra' in configuration, but corresponding extensions are missing.");
-		}
-
-		foreach ($this->extensions as $name => $extension) {
-			$extension->loadConfiguration();
 		}
 	}
 


### PR DESCRIPTION
With this change, it would be possible to register extensions by another extension. Registration of extension is now possible only in PHP. Because it's (as far as I've seen) always just `$name => new $class`, it would be great to register extensions in config file.

@HosipLan already suggested [simple solution](http://forum.nette.org/cs/10875-nette-addons-konvence-a-architektura-aplikace#p80274), but it doesn't work with other type files - it's just hack. With this change, there would be place for helper like this: https://gist.github.com/2864288.
