### PR TITLE
Caching: Added RedisStorage

### DIFF
--- a/Nette/Caching/Storages/RedisStorage.php
+++ b/Nette/Caching/Storages/RedisStorage.php
@@ -1,0 +1,242 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (http://nette.org)
+ *
+ * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
+ *
+ * For the full copyright and license information, please view
+ * the file license.txt that was distributed with this source code.
+ */
+
+namespace Nette\Caching\Storages;
+
+use Nette,
+	Nette\Caching\Cache;
+
+
+
+/**
+ * Memcached storage.
+ *
+ * TODO: Support for multiple Redis instances
+ * TODO: I believe that "priorities", "callbacks" and "tag keys" (set of keys that has tag assigned)
+ *	does not need more namespacing (which would require injecting namespace from Cache)
+ *	because keys itself are namespaced. BUT namespacing would save data transfer
+ * TODO: Check if all callbacks, items and other dependencies are deleted, when key is deleted
+ *
+ * @author     Ondřej Slámečka
+ */
+class RedisStorage extends Nette\Object implements Nette\Caching\IStorage
+{
+	/** @internal cache structure */
+	const NAMESPACE_EXPIRATION = 'expiration',
+		NAMESPACE_TAG_KEYS = 'tagkeys',
+		NAMESPACE_ITEMS = 'di', // dependent items
+		NAMESPACE_CALLBACKS = 'callbacks',
+		KEY_PRIORITIES = 'priorities';
+
+	/** @var \Redis */
+	private $redis;
+
+
+
+	/**
+	 * Checks if Redis extension is available.
+	 * @return bool
+	 */
+	public static function isAvailable()
+	{
+		return extension_loaded('redis');
+	}
+
+
+
+	public function __construct($host = 'localhost', $port = 6379)
+	{
+		if (!static::isAvailable()) {
+			throw new Nette\NotSupportedException("PHP extension 'redis' is not loaded.");
+		}
+
+		$this->redis = new \Redis;
+		$this->redis->connect($host, $port);
+	}
+
+
+
+	/**
+	 * Read from cache.
+	 * @param  string key
+	 * @return mixed|NULL
+	 */
+	public function read($key)
+	{
+		$value = $this->redis->get($key) ?: NULL;
+
+		$slidingExpirationKey = self::NAMESPACE_EXPIRATION . Cache::NAMESPACE_SEPARATOR . $key;
+		$expiration = $this->redis->get($slidingExpirationKey);
+		if ($expiration) {
+			$this->redis->setTimeout($key, $expiration);
+			$this->redis->setTimeout($slidingExpirationKey, $expiration);
+		}
+
+		$callbacks = $this->redis->sMembers(self::NAMESPACE_CALLBACKS . Cache::NAMESPACE_SEPARATOR . $key);
+		if (!empty($callbacks)) {
+			$callbacks = array_map('unserialize', $callbacks);
+
+			if (!Cache::checkCallbacks($callbacks)) {
+				$this->redis->delete($key, 0);
+				return NULL;
+			}
+		}
+
+		return $value;
+	}
+
+
+
+	/**
+	 * Prevents item reading and writing. Lock is released by write() or remove().
+	 * @param  string key
+	 * @return void
+	 */
+	public function lock($key)
+	{
+		// TODO: http://redis.io/topics/transactions ?
+	}
+
+
+
+	/**
+	 * Writes item into the cache.
+	 * @param  string key
+	 * @param  mixed  data
+	 * @param  array  dependencies
+	 * @return void
+	 */
+	public function write($key, $data, array $dependencies)
+	{
+		$this->redis->set($key, $data);
+
+		if (isset($dependencies[Cache::ITEMS])) {
+			foreach ($dependencies[Cache::ITEMS] as $item) {
+				$this->redis->sAdd(self::NAMESPACE_ITEMS . Cache::NAMESPACE_SEPARATOR . $item, $key);
+			}
+		}
+
+		if ($dependentItems = $this->redis->sMembers(self::NAMESPACE_ITEMS . Cache::NAMESPACE_SEPARATOR . $key)) {
+			$this->redis->delete($dependentItems);
+		}
+
+		if (isset($dependencies[Cache::TAGS])) {
+			$dependencies[Cache::TAGS] = (array) $dependencies[Cache::TAGS];
+
+			foreach ($dependencies[Cache::TAGS] as $tag) {
+				$this->redis->sAdd(self::NAMESPACE_TAG_KEYS . Cache::NAMESPACE_SEPARATOR . $tag, $key);
+			}
+		}
+
+		if (isset($dependencies[Cache::CALLBACKS])) {
+			foreach ($dependencies[Cache::CALLBACKS] as $cb) {
+				$this->redis->sAdd(self::NAMESPACE_CALLBACKS . Cache::NAMESPACE_SEPARATOR . $key, serialize($cb));
+			}
+		}
+
+		if (isset($dependencies[Cache::PRIORITY])) {
+			$this->redis->zAdd(self::KEY_PRIORITIES, $dependencies[Cache::PRIORITY], $key);
+		}
+
+		if (isset($dependencies[Cache::EXPIRATION])) {
+			$this->redis->setTimeout($key, $dependencies[Cache::EXPIRATION]);
+
+			if (isset($dependencies[Cache::SLIDING])) {
+				$slidingExpirationKey = self::NAMESPACE_EXPIRATION . Cache::NAMESPACE_SEPARATOR . $key;
+				$this->redis->set($slidingExpirationKey, $dependencies[Cache::EXPIRATION]);
+				$this->redis->setTimeout($slidingExpirationKey, $dependencies[Cache::EXPIRATION]);
+			}
+		}
+	}
+
+
+
+	/**
+	 * Removes item from the cache.
+	 * @param  string key
+	 * @return void
+	 */
+	public function remove($key)
+	{
+		$this->redis->delete($key);
+
+		if ($dependentItems = $this->redis->sMembers(self::NAMESPACE_ITEMS . Cache::NAMESPACE_SEPARATOR . $key)) {
+			$this->redis->delete($dependentItems);
+		}
+	}
+
+
+
+	/**
+	 * Removes items from the cache by conditions.
+	 * @param  array  conditions
+	 * @return void
+	 */
+	public function clean(array $conds)
+	{
+		if (!empty($conds[Cache::ALL])) {
+			$this->redis->flushDB();
+		} else {
+			$keys = array();
+
+			if (isset($conds[Cache::PRIORITY])) {
+
+				$byPriority = $this->redis->zRangeByScore(self::KEY_PRIORITIES, 0, $conds[Cache::PRIORITY]);
+				self::arrayAppend($keys, $byPriority);				
+
+				$this->redis->zDeleteRangeByScore(self::KEY_PRIORITIES, 0, $conds[Cache::PRIORITY]);
+			}
+
+			if (isset($conds[Cache::TAGS])) {
+				$conds[Cache::TAGS] = (array) $conds[Cache::TAGS];
+
+				foreach($conds[Cache::TAGS] as $tag) {
+					$byTags = $this->redis->sMembers(self::NAMESPACE_TAG_KEYS . Cache::NAMESPACE_SEPARATOR . $tag);
+					self::arrayAppend($keys, $byTags);
+				}
+			}
+
+			$this->redis->delete($keys);
+
+			// Remove keys keeping information about expiration time
+			$expirationKeys = array_map(function($key) {
+				return self::NAMESPACE_EXPIRATION . Cache::NAMESPACE_SEPARATOR . $key;
+			}, $keys);
+
+			$this->redis->delete($expirationKeys);
+
+			// Remove all dependent items
+			foreach ($keys as $key) {
+				if ($dependentItems = $this->redis->get(self::NAMESPACE_ITEMS . Cache::NAMESPACE_SEPARATOR . $key)) {
+					$this->delete($dependentItems);
+				}
+			}
+		}
+	}
+
+
+
+	/**
+	* Append $append to $array.
+	* This function is much faster then $array = array_merge($array, $append)
+	* Source: http://api.nette.org/2.0/source-Caching.Storages.FileJournal.php.html#1166
+	* @param  array
+	* @param  array
+	* @return void
+	*/
+	private static function arrayAppend(array &$array, array $append)
+	{
+		foreach ($append as $value) {
+			$array[] = $value;
+		}
+	}
+
+}

--- a/tests/Nette/Caching/Redis.callbacks.phpt
+++ b/tests/Nette/Caching/Redis.callbacks.phpt
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Test: Nette\Caching\Storages\RedisStorage expiration test.
+ *
+ * @author     David Grudl, Ondřej Slámečka
+ * @package    Nette\Caching
+ * @subpackage UnitTests
+ */
+
+use Nette\Caching\Storages\RedisStorage,
+	Nette\Caching\Cache;
+
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+
+if (!RedisStorage::isAvailable()) {
+	TestHelpers::skip('Requires PHP extension Redis.');
+}
+
+
+
+$key = 'nette-expiration-key';
+$value = 'rulez';
+
+$cache = new Cache(new RedisStorage('localhost'));
+
+function dependency($val)
+{
+	return $val;
+}
+
+
+// Writing cache...
+$cache->save($key, $value, array(
+	Cache::CALLBACKS => array(array('dependency', 1)),
+));
+
+Assert::true( isset($cache[$key]), 'Is cached?' );
+
+
+
+// Writing cache...
+$cache->save($key, $value, array(
+	Cache::CALLBACKS => array(array('dependency', 0)),
+));
+
+Assert::false( isset($cache[$key]), 'Is cached?' );

--- a/tests/Nette/Caching/Redis.expiration.phpt
+++ b/tests/Nette/Caching/Redis.expiration.phpt
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Test: Nette\Caching\Storages\RedisStorage expiration test.
+ *
+ * @author     David Grudl, Ondřej Slámečka
+ * @package    Nette\Caching
+ * @subpackage UnitTests
+ */
+
+use Nette\Caching\Storages\RedisStorage,
+	Nette\Caching\Cache;
+
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+
+if (!RedisStorage::isAvailable()) {
+	TestHelpers::skip('Requires PHP extension Redis.');
+}
+
+
+
+$key = 'nette-expiration-key';
+$value = 'rulez';
+
+$cache = new Cache(new RedisStorage('localhost'));
+
+
+// Writing cache...
+$cache->save($key, $value, array(
+	Cache::EXPIRATION => time() + 3,
+));
+
+
+// Sleeping 1 second
+sleep(1);
+Assert::true( isset($cache[$key]), 'Is cached?' );
+
+
+
+// Sleeping 3 seconds
+sleep(3);
+Assert::false( isset($cache[$key]), 'Is cached?' );

--- a/tests/Nette/Caching/Redis.items.phpt
+++ b/tests/Nette/Caching/Redis.items.phpt
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Test: Nette\Caching\Storages\RedisStorage dependent items test.
+ *
+ * @author     David Grudl, Ondřej Slámečka
+ * @package    Nette\Caching
+ * @subpackage UnitTests
+ */
+
+use Nette\Caching\Storages\RedisStorage,
+	Nette\Caching\Cache;
+
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+
+if (!RedisStorage::isAvailable()) {
+	TestHelpers::skip('Requires PHP extension Redis.');
+}
+
+$key = 'nette';
+$value = 'rulez';
+
+$cache = new Cache(new RedisStorage('localhost'));
+
+
+
+// Writing cache...
+$cache->save($key, $value, array(
+	Cache::ITEMS => array('dependent'),
+));
+
+Assert::true( isset($cache[$key]), 'Is cached?' );
+
+
+// Modifing dependent cached item
+$cache['dependent'] = 'hello world';
+
+Assert::false( isset($cache[$key]), 'Is cached?' );
+
+
+// Writing cache...
+$cache->save($key, $value, array(
+	Cache::ITEMS => 'dependent',
+));
+
+Assert::true( isset($cache[$key]), 'Is cached?' );
+
+
+// Modifing dependent cached item
+sleep(2);
+$cache['dependent'] = 'hello europe';
+
+Assert::false( isset($cache[$key]), 'Is cached?' );
+
+
+// Writing cache...
+$cache->save($key, $value, array(
+	Cache::ITEMS => 'dependent',
+));
+
+Assert::true( isset($cache[$key]), 'Is cached?' );
+
+
+// Deleting dependent cached item
+$cache['dependent'] = NULL;
+
+Assert::false( isset($cache[$key]), 'Is cached?' );

--- a/tests/Nette/Caching/Redis.priority.phpt
+++ b/tests/Nette/Caching/Redis.priority.phpt
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Test: Nette\Caching\Storages\RedisStorage priority test.
+ *
+ * @author     David Grudl, Ondřej Slámečka
+ * @package    Nette\Caching
+ * @subpackage UnitTests
+ */
+
+use Nette\Caching\Storages\RedisStorage,
+	Nette\Caching\Cache;
+
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+
+if (!RedisStorage::isAvailable()) {
+	TestHelpers::skip('Requires PHP extension Redis.');
+}
+
+
+$cache = new Cache(new RedisStorage('localhost'));
+
+
+// Writing cache...
+$cache->save('nette-priority-key1', 'value1', array(
+	Cache::PRIORITY => 100,
+));
+
+$cache->save('nette-priority-key2', 'value2', array(
+	Cache::PRIORITY => 200,
+));
+
+$cache->save('nette-priority-key3', 'value3', array(
+	Cache::PRIORITY => 300,
+));
+
+$cache['nette-priority-key4'] = 'value4';
+
+
+// Cleaning by priority...
+$cache->clean(array(
+	Cache::PRIORITY => '200',
+));
+
+Assert::false( isset($cache['nette-priority-key1']), 'Is cached nette-priority-key1?' );
+Assert::false( isset($cache['nette-priority-key2']), 'Is cached nette-priority-key2?' );
+Assert::true( isset($cache['nette-priority-key3']), 'Is cached nette-priority-key3?' );
+Assert::true( isset($cache['nette-priority-key4']), 'Is cached nette-priority-key4?' );

--- a/tests/Nette/Caching/Redis.sliding.phpt
+++ b/tests/Nette/Caching/Redis.sliding.phpt
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Test: Nette\Caching\Storages\RedisStorage sliding expiration test.
+ *
+ * @author     David Grudl, Ondřej Slámečka
+ * @package    Nette\Caching
+ * @subpackage UnitTests
+ */
+
+use Nette\Caching\Storages\RedisStorage,
+	Nette\Caching\Cache;
+
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+
+if (!RedisStorage::isAvailable()) {
+	TestHelpers::skip('Requires PHP extension Redis.');
+}
+
+
+
+$key = 'nette-sliding-key';
+$value = 'rulez';
+
+$cache = new Cache(new RedisStorage('localhost'));
+
+
+// Writing cache...
+$cache->save($key, $value, array(
+	Cache::EXPIRATION => time() + 2,
+	Cache::SLIDING => TRUE,
+));
+
+
+for($i = 0; $i < 3; $i++) {
+	// Sleeping 1 second
+	sleep(1);
+	Assert::true( isset($cache[$key]), 'Is cached?' );
+
+}
+
+// Sleeping few seconds...
+sleep(3);
+
+Assert::false( isset($cache[$key]), 'Is cached?' );

--- a/tests/Nette/Caching/Redis.tags.phpt
+++ b/tests/Nette/Caching/Redis.tags.phpt
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Test: Nette\Caching\Storages\RedisStorage tags dependency test.
+ *
+ * @author     David Grudl, Ondřej Slámečka
+ * @package    Nette\Caching
+ * @subpackage UnitTests
+ */
+
+use Nette\Caching\Storages\RedisStorage,
+	Nette\Caching\Cache;
+
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+
+if (!RedisStorage::isAvailable()) {
+	TestHelpers::skip('Requires PHP extension Redis.');
+}
+
+
+$cache = new Cache(new RedisStorage('localhost'));
+
+
+// Writing cache...
+$cache->save('nette-tags-key1', 'value1', array(
+	Cache::TAGS => array('one', 'two'),
+));
+
+$cache->save('nette-tags-key2', 'value2', array(
+	Cache::TAGS => array('one', 'three'),
+));
+
+$cache->save('nette-tags-key3', 'value3', array(
+	Cache::TAGS => array('two', 'three'),
+));
+
+$cache['nette-tags-key4'] = 'value4';
+
+
+// Cleaning by tags...
+$cache->clean(array(
+	Cache::TAGS => 'one',
+));
+
+Assert::false( isset($cache['nette-tags-key1']), 'Is cached nette-tags-key1?' );
+Assert::false( isset($cache['nette-tags-key2']), 'Is cached nette-tags-key2?' );
+Assert::true( isset($cache['nette-tags-key3']), 'Is cached nette-tags-key3?' );
+Assert::true( isset($cache['nette-tags-key4']), 'Is cached nette-tags-key4?' );


### PR DESCRIPTION
Here is RedisStorage code I've developed inspired by MemcachedStorage and FileStorage. Advantage of RedisStorage is that it does not need a journal. I have used PHP extension https://github.com/nicolasff/phpredis

Work is still in progress and problems are mentioned in TODOs but tests passes. One problem not mentioned in code is creation of instance of Redis in constructor of RedisStorage. This should be injected but I kept it the way it is to be consistent with MemcachedStorage.

Please express your opinions about code or if possible add your own :-)
