### PR TITLE
Added method for retrieval of IBarPanel from Bar

### DIFF
--- a/Nette/Diagnostics/Bar.php
+++ b/Nette/Diagnostics/Bar.php
@@ -48,6 +48,18 @@ class Bar extends Nette\Object
 
 
 	/**
+	 * Returns panel with given id
+	 * @param  string
+	 * @return IBarPanel|NULL
+	 */
+	public function getPanel($id)
+	{
+		return isset($this->panels[$id]) ? $this->panels[$id] : NULL;
+	}
+
+
+
+	/**
 	 * Renders debug bar.
 	 * @return void
 	 */


### PR DESCRIPTION
Ability to get instance of already added panel brings new possibilities, like adding barDumps to payload in Ajax request. With that possible, this script could work without use of `ReflectionProperty::setAccessible()`: https://github.com/vojtech-dobes/nette.ajax.js/blob/master/extensions/diagnostics.dumps.ajax.js
