### PR TITLE
Composer: add autoload files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
 			"homepage": "https://github.com/nette/nette/contributors"
 		}
 	],
+	"autoload": {
+		"files": ["Nette/loader.php"]
+	},
 	"extra": {
 		"branch-alias": {
 			"dev-master": "2.1-dev"


### PR DESCRIPTION
Composer now include nette via `Nette/loader.php`.

No more

``` php
<?php
require LIBS_DIR . '/autoload.php';
require LIBS_DIR . '/nette/nette/Nette/loader.php';
```

Just

``` php
<?php
require LIBS_DIR . '/autoload.php';
```
