### PR TITLE
Template variable should also be prefixed with underscore.

### DIFF
--- a/Nette/Templating/Template.php
+++ b/Nette/Templating/Template.php
@@ -319,7 +319,7 @@ class Template extends Nette\Object implements ITemplate
 	 */
 	public function getParameters()
 	{
-		$this->params['template'] = $this;
+		$this->params['_template'] = $this->params['template'] = $this;
 		return $this->params;
 	}
 


### PR DESCRIPTION
I don't know all the places where the $template is used and therefore didn't change them.
