### PR TITLE
netteForms.js: disables HTML5 validation at all browsers

### DIFF
--- a/client-side/forms/netteForms.js
+++ b/client-side/forms/netteForms.js
@@ -263,7 +263,7 @@ Nette.toggle = function(id, visible) {
 
 
 Nette.initForm = function(form) {
-	form.noValidate = true;
+	form.noValidate = 'novalidate';
 
 	Nette.addEvent(form, 'submit', function() {
 		return Nette.validateForm(form);


### PR DESCRIPTION
V Opeře nefungovalo automatické vypnutí validace. 

Změna testována v následujících browserech: Opera 12 IE9, FF13 a Chrome 20
