### PR TITLE
Presenter sendJson method

### DIFF
--- a/Nette/Application/UI/Presenter.php
+++ b/Nette/Application/UI/Presenter.php
@@ -625,6 +625,19 @@ abstract class Presenter extends Control implements Application\IPresenter
 
 
 
+	/**
+	 * Sends JSON data to the output.
+	 * @param mixed $data
+	 * @return void
+	 * @throws Nette\Application\AbortException
+	 */
+	public function sendJson($data)
+	{
+		$this->sendResponse(new Responses\JsonResponse($data));
+	}
+
+
+
 	/********************* navigation & flow ****************d*g**/
 
 


### PR DESCRIPTION
Běžně json posílám přes metodu sendResponse. Mám pocit, že to mám více pod kontrolou než s tím payloadem. Ale je to vždycky hrozně práce vyrobit ten use, new JsonResponse a tak. Proto mi přijde zkratka sendJson jako dobrý nápad.
