### PR TITLE
tests: fix session.save_path in session storage test

### DIFF
--- a/tests/Nette/Http/Session.storage.phpt
+++ b/tests/Nette/Http/Session.storage.phpt
@@ -17,6 +17,9 @@ use Nette\Object,
 require __DIR__ . '/../bootstrap.php';
 
 
+ini_set('session.save_path', TEMP_DIR);
+
+
 
 class MySessionStorage extends Object implements ISessionStorage
 {


### PR DESCRIPTION
fix for:

```
Failures:

-> Nette\Http\Session::regenerateId()
   file: c:\Workspace\Nette\framework\tests\Nette\Http\Session.regenerateId().phpt

Failed asserting that FALSE is TRUE in file C:\Workspace\Nette\framework\tests\Nette\Http\Session.regenerateId().phpt on line 26

-> Nette\Http\Session storage.
   file: c:\Workspace\Nette\framework\tests\Nette\Http\Session.storage.phpt
   Error: file_put_contents(/sess_ap00l6fj1pamin2oh1is6bj5e1): failed to open stream: Permission denied in C:\Workspace\Nette\framework\tests\Nette\Http\Session.storage.phpt:41
```
