### PR TITLE
phpdoc typo

### DIFF
--- a/Nette/Application/UI/Presenter.php
+++ b/Nette/Application/UI/Presenter.php
@@ -109,7 +109,7 @@ abstract class Presenter extends Control implements Application\IPresenter
 	/** @var array */
 	private $lastCreatedRequestFlag;
 
-	/** @var Nette\DI\Container */
+	/** @var \SystemContainer|Nette\DI\Container */
 	private $context;
 
 	/** @var Nette\Application\Application */


### PR DESCRIPTION
Fixes PhpEd bug when intelliSense prefere private phpdoc over property-read definition.
