### PR TITLE
Experiment: Cloud storage for bluescreen dumps

### DIFF
--- a/Nette/Diagnostics/templates/bluescreen.phtml
+++ b/Nette/Diagnostics/templates/bluescreen.phtml
@@ -53,6 +53,7 @@ $counter = 0;
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="robots" content="noindex,noarchive">
 	<meta name="generator" content="Nette Framework">
+	<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
 
 	<title><?php echo htmlspecialchars($title) ?></title><!-- <?php
 		$ex = $exception; echo htmlspecialchars($ex->getMessage() . ($ex->getCode() ? ' #' . $ex->getCode() : ''));
@@ -298,7 +299,11 @@ $counter = 0;
 		<div id="netteBluescreenError" class="panel">
 			<h1><?php echo htmlspecialchars($title), ($exception->getCode() ? ' #' . $exception->getCode() : '') ?></h1>
 
-			<p><?php echo htmlspecialchars($exception->getMessage()) ?> <a href="http://www.google.cz/search?sourceid=nette&amp;q=<?php echo urlencode($title . ' ' . preg_replace('#\'.*\'|".*"#Us', '', $exception->getMessage())) ?>" id="netteBsSearch">search&#x25ba;</a></p>
+			<p>
+				<?php echo htmlspecialchars($exception->getMessage()) ?>
+				<a href="http://www.google.cz/search?sourceid=nette&amp;q=<?php echo urlencode($title . ' ' . preg_replace('#\'.*\'|".*"#Us', '', $exception->getMessage())) ?>" id="netteBsSearch">search&#x25ba;</a>
+				<a href="#" onclick="storeToCloud(); return false;" id="netteBsSearch">cloud&#x25ba;</a>
+			</p>
 		</div>
 
 
@@ -643,6 +648,22 @@ $counter = 0;
 		}
 		return false;
 	};
+
+	function storeToCloud() {
+		$.post('http://ladenka.juzna.cz/record/add?message=' + $('#netteBluescreenError p')[0].firstChild.nodeValue.trim(),
+			{
+				content: document.getElementById('netteBluescreen').innerHTML
+			},
+			function(res) {
+				if (res && res.link) {
+					window.open(res.link)
+				} else {
+					alert("Uploaded to cloud");
+				}
+				console.log(res);
+			}
+		);
+	}
 </script>
 </body>
 </html>


### PR DESCRIPTION
_Upload bluescreen dump (Ladenka) by one click, share link with others to get quick help._

This is just a proof of concept and request for discussion.

**Motivation:**
Someone has problem, so she copy&pastes error message into forum/chat and asks for help. But with very few details it's so hard to spot the problem. 

What if she could have shared full dump with just one click and share this instead. The community would solve problems much faster and help much more people.

**Example:**
In your dump:
![one click example](http://files.ukaz.at/images/full/2rn.png)

Result:
http://ladenka.juzna.cz/record/1aecd741bc6488e53d0acd443cfac84a27ba70ef

**Notes:**
- this is just a quick hack
- server needs to be configurable (in config.neon)
- cloud service will be opensourced so that companies can run their private instances
- will not use jQuery (it is there just to make it quickly)
