### PR TITLE
static position for display scroll in bar

### DIFF
--- a/Nette/Diagnostics/templates/bar.phtml
+++ b/Nette/Diagnostics/templates/bar.phtml
@@ -410,7 +410,7 @@ var Panel = Nette.Debug.Panel = Nette.Class({
 		if (!win) return;
 
 		doc = win.document;
-		doc.write('<!DOCTYPE html><meta http-equiv="Content-Type" content="text\/html; charset=utf-8"><style>' + $('#nette-debug-style').dom().innerHTML + '<\/style><script>' + $('#nette-debug-script').dom().innerHTML + '<\/script><body id="nette-debug">');
+		doc.write('<!DOCTYPE html><meta http-equiv="Content-Type" content="text\/html; charset=utf-8"><style>' + $('#nette-debug-style').dom().innerHTML + '#nette-debug{position:static;}<\/style><script>' + $('#nette-debug-script').dom().innerHTML + '<\/script><body id="nette-debug">');
 		doc.body.innerHTML = '<div class="nette-panel nette-mode-window" id="' + id + '">' + this.dom().innerHTML + '<\/div>';
 		win.Nette.Debug.Panel.factory(id).initToggler().reposition();
 		doc.title = panel.find('h1').dom().innerHTML;


### PR DESCRIPTION
If you have long list, for example routes, you can't see all. And if click "open in window", now you can.
