### PR TITLE
Config\Extensions\NetteExtension: header() called only if !headers_sent()

### DIFF
--- a/Nette/Config/Extensions/NetteExtension.php
+++ b/Nette/Config/Extensions/NetteExtension.php
@@ -373,7 +373,7 @@ class NetteExtension extends Nette\Config\CompilerExtension
 		}
 
 		if (isset($config['security']['frames'])) {
-			$initialize->addBody('header(?);', array('X-Frame-Options: ' . $config['security']['frames']));
+			$initialize->addBody('headers_sent() || header(?);', array('X-Frame-Options: ' . $config['security']['frames']));
 		}
 
 		foreach ($container->findByTag('run') as $name => $on) {


### PR DESCRIPTION
If there is the **security.frames** configuration option set to any value except **TRUE** the `header()` function call is added to the `SystemContainer::initialize()` method.

If there is some output before the container's initialize method is called (nothing unusual in scripts, tests, etc.) this causes `Nette\FatalErrorException` with the message **"Cannot modify header information - headers already sent by (output started at ...)"**

Perhaps some test of `$consoleMode` or `headers_sent()` should be added to the definition.

Now it is needed to use this `config.neon` file for tests to disable `header()` function call addition:

```
nette:
    security:
        frames: on
```
