### PR TITLE
Object: allow traversable objects in event property

### DIFF
--- a/Nette/common/ObjectMixin.php
+++ b/Nette/common/ObjectMixin.php
@@ -63,7 +63,7 @@ final class ObjectMixin
 			return call_user_func_array($_this->$name, $args);
 
 		} elseif ($isProp === 'event') { // calling event handlers
-			if (is_array($_this->$name)) {
+			if (is_array($_this->$name) || $_this->$name instanceof \Traversable) {
 				foreach ($_this->$name as $handler) {
 					callback($handler)->invokeArgs($args);
 				}


### PR DESCRIPTION
The event property must contain array-like structure, so it can be traversed. I'm experimenting with something and this would be really handy.

With this, I can do

```
$form->onSuccess = new ArrayHash();
```

and it still wors, because it can iterate over the object.
