### PR TITLE
Nette\Templating\Template: Fix check of filter double registration

### DIFF
--- a/Nette/Templating/Template.php
+++ b/Nette/Templating/Template.php
@@ -35,6 +35,9 @@ class Template extends Nette\Object implements ITemplate
 	/** @var array compile-time filters */
 	private $filters = array();
 
+	/** @var array native filters for double registration check */
+	private $nativeFilters = array();
+
 	/** @var array run-time helpers */
 	private $helpers = array();
 
@@ -168,13 +171,14 @@ class Template extends Nette\Object implements ITemplate
 	 * @param  callable
 	 * @return Template  provides a fluent interface
 	 */
-	public function registerFilter($callback)
+	public function registerFilter($nativeCallback)
 	{
-		$callback = callback($callback);
-		if (in_array($callback, $this->filters)) {
+		$callback = callback($nativeCallback);
+		if (in_array($nativeCallback, $this->nativeFilters, TRUE)) {
 			throw new Nette\InvalidStateException("Filter '$callback' was registered twice.");
 		}
 		$this->filters[] = $callback;
+		$this->nativeFilters[] = $nativeCallback;
 		return $this;
 	}
 

--- a/tests/Nette/Templating/Template.registerFilter().differentTypes.phpt
+++ b/tests/Nette/Templating/Template.registerFilter().differentTypes.phpt
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Test: Nette\Templating\Template::registerFilter()
+ *
+ * @author     Josef Cech
+ * @package    Nette\Templating
+ * @subpackage UnitTests
+ */
+
+use Nette\Templating\Template;
+use Nette\Latte;
+
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+
+$template = new Template();
+$template->registerFilter(function () {});
+$template->registerFilter(new Latte\Engine());

--- a/tests/Nette/Templating/Template.registerFilter().doubleRegister.phpt
+++ b/tests/Nette/Templating/Template.registerFilter().doubleRegister.phpt
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Test: Nette\Templating\Template::registerFilter()
+ *
+ * @author     Josef Cech
+ * @package    Nette\Templating
+ * @subpackage UnitTests
+ */
+
+use Nette\Templating\Template;
+use Nette\Latte;
+
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+
+Assert::throws(function() {
+	$filter = new Latte\Engine();
+	$template = new Template();
+	$template->registerFilter($filter);
+	$template->registerFilter($filter);
+}, 'Nette\InvalidStateException', "Filter 'Nette\Latte\Engine::__invoke' was registered twice.");
+
+Assert::throws(function() {
+	$template = new Template();
+	$template->registerFilter('strtolower');
+	$template->registerFilter('strtolower');
+}, 'Nette\InvalidStateException', "Filter 'strtolower' was registered twice.");


### PR DESCRIPTION
Změna není plně zpětně kompatibilní kvůli rozdílu porovnávání == a === pro objekty.

Fix issue: https://github.com/nette/nette/issues/729
