### PR TITLE
Tests: on linux resolve php executable automatically

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -8,7 +8,19 @@ if echo $dir | grep -v ^/ > /dev/null; then
 	dir=` pwd `/$dir
 fi
 
+while getopts "p:" opt;
+do
+    case $opt in
+        p) php_exec=$OPTARG ;;
+    esac
+done
+
+
 # runs RunTests.php with script's arguments
-php "$dir/Test/RunTests.php" $*
+if [ ! -x "$php_exec" ]; then
+    php "$dir/Test/RunTests.php" -p `which php` $*
+else
+    php "$dir/Test/RunTests.php" $*
+fi
 
 # returns what script returned


### PR DESCRIPTION
S bashem nejsme kamarádi, jen známí. Tedy nevím jak to napsat lépe. Každopádně to plní účel. Na linuxu jsem musel specifikovat cestu k phpku ručně a to je opravdu otrava.

Nyní stačí napsat

```
$ ./tests/run-tests.sh
```
