### PR TITLE
Config: test case for invalid characters in service name

### DIFF
--- a/tests/Nette/Config/Configurator.loadConfig.errors.phpt
+++ b/tests/Nette/Config/Configurator.loadConfig.errors.phpt
@@ -14,10 +14,15 @@ use Nette\Config\Configurator;
 require __DIR__ . '/../bootstrap.php';
 
 
-
-$configurator = new Configurator;
-
-Assert::exception(function() use ($configurator) {
+Assert::throws(function() {
+	$configurator = new Configurator;
 	$configurator->addConfig('files/config1.neon')
 		->createContainer();
 }, 'Nette\InvalidStateException', "Set path to temporary directory using setTempDirectory().");
+
+Assert::throws(function () {
+	$configurator = new Configurator;
+	$configurator->addConfig('files/config.serviceIdentifiers.neon', $configurator::NONE)
+		->setTempDirectory(TEMP_DIR)
+		->createContainer();
+}, 'Nette\DI\ServiceCreationException', "Service 'Nette\\Latte\\Token': Name contains invalid characters.");

--- a/tests/Nette/Config/files/config.serviceIdentifiers.neon
+++ b/tests/Nette/Config/files/config.serviceIdentifiers.neon
@@ -1,0 +1,4 @@
+services:
+	Nette\Latte\Token:
+		class: Nette\Latte\Token
+		run: true


### PR DESCRIPTION
Test case that proves #682 as fixed or bogus.
