### PR TITLE
Update Nette/Application/Responses/FileResponse.php

### DIFF
--- a/Nette/Application/Responses/FileResponse.php
+++ b/Nette/Application/Responses/FileResponse.php
@@ -131,6 +131,7 @@ class FileResponse extends Nette\Object implements Nette\Application\IResponse
 		}
 
 		$httpResponse->setHeader('Content-Length', $length);
+		ob_clean();
 		while (!feof($handle)) {
 			echo fread($handle, 4e6);
 		}


### PR DESCRIPTION
I added ob_clean() before the file is written to the output response, 
because on windows 7 x64/Apache 2.4.2/php 5.4.4 it adds extra LF to the beginning of the output
