### PR TITLE
ComponentModel/Component: added hint to attached()

### DIFF
--- a/Nette/ComponentModel/Component.php
+++ b/Nette/ComponentModel/Component.php
@@ -143,7 +143,7 @@ abstract class Component extends Nette\Object implements IComponent
 	 * @param  IComponent
 	 * @return void
 	 */
-	protected function attached($obj)
+	protected function attached(IComponent $obj)
 	{
 	}
 


### PR DESCRIPTION
Added the `IComponent` typehint to the `Component::attached()` method argument.
