### PR TITLE
Test runner: added help, fixed error messages

### DIFF
--- a/tests/Test/RunTests.php
+++ b/tests/Test/RunTests.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/TestRunner.php';
 /**
  * Help
  */
-if (!isset($_SERVER['argv'][1])) { ?>
+if (!isset($_SERVER['argv'][1]) || $_SERVER['argv'][1] === '-h' || $_SERVER['argv'][1] === '--help') { ?>
 Usage:
 	php RunTests.php [options] [file or directory]
 
@@ -22,6 +22,9 @@ Options:
 	-j <num>    Run <num> jobs in parallel.
 
 <?php
+	if (isset($_SERVER['argv'][1])) {
+		exit(0);
+	}
 }
 
 

--- a/tests/Test/TestRunner.php
+++ b/tests/Test/TestRunner.php
@@ -59,6 +59,9 @@ class TestRunner
 		$failed = $passed = $skipped = array();
 
 		exec($this->phpEnvironment . escapeshellarg($this->phpBinary) . ' -v', $output);
+		if (!isset($output[0])) {
+			return FALSE;
+		}
 		echo "$output[0] | $this->phpBinary $this->phpArgs $this->phpEnvironment\n\n";
 
 		$tests = array();

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -7,8 +7,16 @@ dir=` dirname $0 `
 if echo $dir | grep -v ^/ > /dev/null; then
 	dir=` pwd `/$dir
 fi
+runner="$dir/Test/RunTests.php";
 
-while getopts "p:" opt;
+case $1 in
+	"-h"|"--help")
+		php $runner --help
+		exit 0
+	;;
+esac
+
+while getopts "p:c:log:d:l:s:j:" opt;
 do
     case $opt in
         p) php_exec=$OPTARG ;;
@@ -18,9 +26,9 @@ done
 
 # runs RunTests.php with script's arguments
 if [ ! -x "$php_exec" ]; then
-    php "$dir/Test/RunTests.php" -p `which php` $*
+    php $runner -p `which php` $*
 else
-    php "$dir/Test/RunTests.php" $*
+    php $runner $*
 fi
 
 # returns what script returned


### PR DESCRIPTION
Added support for (pretty standard) 

```
$ ./tests/run-tests.sh -h
$ ./tests/run-tests.sh --help
```

And fixed two notices.
