### PR TITLE
Update client-side/forms/netteForms.js

### DIFF
--- a/client-side/forms/netteForms.js
+++ b/client-side/forms/netteForms.js
@@ -226,7 +226,15 @@ Nette.validators = {
 
 	submitted: function(elem, arg, val) {
 		return elem.form['nette-submittedBy'] === elem;
-	}
+	},
+	
+	fileSize: function(elem, arg, val) {
+		if (typeof FileReader !== "undefined") {
+			return elem.files[0].size <= arg;
+		} else {
+			return true;
+		}
+	}	
 };
 
 


### PR DESCRIPTION
I'm proposing to add the file size check on client's side which degrades gracefully. I'm aware that the feature is not supported on all major browsers (current support: http://caniuse.com/#search=filereader API).

Please share your opinion.
