### PR TITLE
Http\Response: added setContentLength(), fixed PHP bug #44164

### DIFF
--- a/Nette/Application/Responses/FileResponse.php
+++ b/Nette/Application/Responses/FileResponse.php
@@ -128,7 +128,7 @@ class FileResponse extends Nette\Object implements Nette\Application\IResponse
 			}
 		}
 
-		$httpResponse->setHeader('Content-Length', $length);
+		$httpResponse->setContentLength($length);
 		while (!feof($handle) && $length > 0) {
 			echo $s = fread($handle, min(4e6, $length));
 			$length -= strlen($s);

--- a/Nette/Http/IResponse.php
+++ b/Nette/Http/IResponse.php
@@ -87,6 +87,13 @@ interface IResponse
 	function setContentType($type, $charset = NULL);
 
 	/**
+	 * Sends a Content-length HTTP header.
+	 * @param  int     length
+	 * @return void
+	 */
+	function setContentLength($length);
+
+	/**
 	 * Redirects to a new URL.
 	 * @param  string  URL
 	 * @param  int     HTTP code

--- a/Nette/Http/Response.php
+++ b/Nette/Http/Response.php
@@ -149,6 +149,22 @@ final class Response extends Nette\Object implements IResponse
 
 
 	/**
+	 * Sends a Content-length HTTP header.
+	 * @param  int     length
+	 * @return Response  provides a fluent interface
+	 * @throws Nette\InvalidStateException  if HTTP headers have been sent
+	 */
+	public function setContentLength($length)
+	{
+		if (!ini_get('zlib.output_compression')) { // PHP bug #44164
+			$this->setHeader('Content-Length', $length);
+		}
+		return $this;
+	}
+
+
+
+	/**
 	 * Redirects to a new URL. Note: call exit() after it.
 	 * @param  string  URL
 	 * @param  int     HTTP code


### PR DESCRIPTION
http://forum.nette.org/cs/7889-nefukcni-fileresponse-v-google-chrome#p88271
