### PR TITLE
Database: fixed isset($row[int])

### DIFF
--- a/Nette/Database/Row.php
+++ b/Nette/Database/Row.php
@@ -44,4 +44,15 @@ class Row extends Nette\ArrayHash
 		return $this->$key;
 	}
 
+
+
+	public function offsetExists($key)
+	{
+		if (is_int($key)) {
+			$arr = array_values((array) $this);
+			return array_key_exists($key, $arr);
+		}
+		return parent::offsetExists($key);
+	}
+
 }


### PR DESCRIPTION
`isset($row[1])` doesn't work properly and it's used e.g. in `Nette/Database/Drivers/MySqlDriver.php::getTables`
