### PR TITLE
typo: "Parameter Parameter"

### DIFF
--- a/Nette/DI/Helpers.php
+++ b/Nette/DI/Helpers.php
@@ -140,7 +140,7 @@ final class Helpers
 				$optCount++;
 
 			} else {
-				throw new ServiceCreationException("Parameter $parameter has no type hint, so its value must be specified.");
+				throw new ServiceCreationException("$parameter has no type hint, so its value must be specified.");
 			}
 		}
 


### PR DESCRIPTION
Fixes the exception message: "Parameter Parameter $container in Method Vendor\SomeMethod::__construct() has no type hint, so its value must be specified."
