### PR TITLE
Latte: macro {formComponent} should accept object

### DIFF
--- a/Nette/Latte/Macros/FormMacros.php
+++ b/Nette/Latte/Macros/FormMacros.php
@@ -42,7 +42,7 @@ class FormMacros extends MacroSet
 			'Nette\Latte\Macros\FormMacros::renderFormEnd($_form)');
 		$me->addMacro('label', array($me, 'macroLabel'), '?></label><?php');
 		$me->addMacro('input', 'echo $_form[%node.word]->getControl()->addAttributes(%node.array)', NULL, array($me, 'macroAttrInput'));
-		$me->addMacro('formContainer', '$_formStack[] = $_form; $formContainer = $_form = $_form[%node.word]', '$_form = array_pop($_formStack)');
+		$me->addMacro('formContainer', '$_formStack[] = $_form; $formContainer = $_form = (is_object(%node.word) ? %node.word : $_form[%node.word])', '$_form = array_pop($_formStack)');
 	}
 
 


### PR DESCRIPTION
It should be possible to pass form container directly to `{formComponent}` macro:

``` smarty
{formComponent $container}
```
