### PR TITLE
Mail: fixed useless PHP warning if embedded file does not exist

### DIFF
--- a/Nette/Mail/Message.php
+++ b/Nette/Mail/Message.php
@@ -304,7 +304,7 @@ class Message extends MimePart
 	{
 		$part = new MimePart;
 		if ($content === NULL) {
-			$content = file_get_contents($file);
+			$content = @file_get_contents($file); // intentionally @
 			if ($content === FALSE) {
 				throw new Nette\FileNotFoundException("Unable to read file '$file'.");
 			}


### PR DESCRIPTION
Because `Nette\FileNotFoundException` is then thrown.
