### PR TITLE
ComponentModel: check that child component constructor was called

### DIFF
--- a/Nette/ComponentModel/Component.php
+++ b/Nette/ComponentModel/Component.php
@@ -36,6 +36,9 @@ abstract class Component extends Nette\Object implements IComponent
 	/** @var array of [type => [obj, depth, path, is_monitored?]] */
 	private $monitors = array();
 
+	/** @var bool */
+	protected $constructorCheck = FALSE;
+
 
 
 	/**
@@ -48,6 +51,8 @@ abstract class Component extends Nette\Object implements IComponent
 		} elseif (is_string($name)) {
 			$this->name = $name;
 		}
+
+		$this->constructorCheck = TRUE;
 	}
 
 

--- a/Nette/ComponentModel/Container.php
+++ b/Nette/ComponentModel/Container.php
@@ -219,6 +219,10 @@ class Container extends Component implements IContainer
 	 */
 	protected function validateChildComponent(IComponent $child)
 	{
+		if ($child instanceof Component && $child->constructorCheck !== TRUE) {
+			$method = Nette\Reflection\Method::from($child, '__construct');
+			throw new Nette\InvalidStateException("Method $method or its descendant doesn't call parent::__construct().");
+		}
 	}
 
 


### PR DESCRIPTION
Toto vynucuje best-practises a zároveň řeší problém se zapomenutým voláním `parent::__construct()` v poděděném `PresenterComponent` nebo `UI\Control`.

Vidíš v tom smysl @dg? Mám dopsat testy? Víš jak to udělat lépe?
