### PR TITLE
Added support for external helper loader

### DIFF
--- a/Nette/Templating/Helpers.php
+++ b/Nette/Templating/Helpers.php
@@ -48,6 +48,9 @@ final class Helpers
 		'number' => 'number_format',
 	);
 
+	/** @var IHelperLoader external loader of helpers */
+	private static $helperLoader;
+
 	/** @var string default date format */
 	public static $dateFormat = '%x';
 
@@ -64,7 +67,20 @@ final class Helpers
 			return new Nette\Callback(__CLASS__, $helper);
 		} elseif (isset(self::$helpers[$helper])) {
 			return self::$helpers[$helper];
+		} elseif (self::$helperLoader instanceof IHelperLoader) {
+			return self::$helperLoader->loadHelper($helper);
 		}
+	}
+
+
+
+	/**
+	 * Sets external helper loader
+	 * @param IHelperLoader
+	 */
+	public static function setHelperLoader(IHelperLoader $helperLoader)
+	{
+		self::$helperLoader = $helperLoader;
 	}
 
 

--- a/Nette/Templating/IHelperLoader.php
+++ b/Nette/Templating/IHelperLoader.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (http://nette.org)
+ *
+ * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
+ *
+ * For the full copyright and license information, please view
+ * the file license.txt that was distributed with this source code.
+ */
+
+namespace Nette\Templating;
+
+
+
+/**
+ * Interface for helper loading class
+ *
+ * @author Filip Halaxa <filip@halaxa.cz>
+ */
+interface IHelperLoader
+{
+
+	/**
+	 * Try to load the requested helper.
+	 * @param  string  helper name
+	 * @return callable
+	 */
+	public function loadHelper($helper);
+
+}


### PR DESCRIPTION
This adds support for automatic helper loading accross application. One can specify external loader (their own class implementing Nette\Templating\IHelperLoader) by calling Nette\Templating\Helper::setHelperLoader($loader) and then just use their own helpers directly in templates without registering them. Example in bootstrap.php:

``` php
$helperLoader = new MyOwnHelperLoader();
Nette\Templating\Helpers::setHelperLoader($helperLoader);
```
