### PR TITLE
MicroPresenter: return 404 when parameter callback is missing

### DIFF
--- a/Nette/Application/MicroPresenter.php
+++ b/Nette/Application/MicroPresenter.php
@@ -71,7 +71,7 @@ class MicroPresenter extends Nette\Object implements Application\IPresenter
 
 		$params = $request->getParameters();
 		if (!isset($params['callback'])) {
-			return;
+			throw new Application\BadRequestException("Parameter callback is missing.");
 		}
 		$params['presenter'] = $this;
 		$callback = new Nette\Callback($params['callback']);


### PR DESCRIPTION
If there is a route, that would accept presenter name `nette.micro`, than the application will respond with `200 OK`.

Example: http://nette.merxes.cz/addons/www/nette.micro/
