### PR TITLE
Config\Configurator: added method addExtension()

### DIFF
--- a/Nette/Config/Configurator.php
+++ b/Nette/Config/Configurator.php
@@ -51,6 +51,21 @@ class Configurator extends Nette\Object
 
 
 	/**
+	 * Adds the given compiler extension to the configurator.
+	 * @param CompilerExtension $extension The extension to be added.
+	 * @return Configurator  provides a fluent interface
+	 */
+	public function addExtension(CompilerExtension $extension) 
+	{
+		$this->onCompile[] = function(Configurator $configurator, Compiler $compiler) use ($extension) {
+			$compiler->addExtension($extension);
+		}
+		return $this;
+	}
+
+
+
+	/**
 	 * Set parameter %debugMode%.
 	 * @param  bool|string|array
 	 * @return Configurator  provides a fluent interface


### PR DESCRIPTION
I've added the method addExtension() to allow to add the compiler
extensions in an easy way.

The only argument against this can be the instance of the extension 
should be created only on compile. But extensions should be a 
lightweight cheap objects so this is acceptable solution in my mind.
If the application don't compile this is a side issue anyway.
