### PR TITLE
Fix: Nette/Config/Extensions/NetteExtension.php

### DIFF
--- a/Nette/Config/Extensions/NetteExtension.php
+++ b/Nette/Config/Extensions/NetteExtension.php
@@ -328,7 +328,7 @@ class NetteExtension extends Nette\Config\CompilerExtension
 			} elseif (is_string($info['reflection'])) {
 				$reflection = new Nette\DI\Statement(preg_match('#^[a-z]+\z#', $info['reflection'])
 					? 'Nette\Database\Reflection\\' . ucfirst($info['reflection']) . 'Reflection'
-					: $info['reflection'], array('@self'));
+					: $info['reflection']);
 			} else {
 				$tmp = Nette\Config\Compiler::filterArguments(array($info['reflection']));
 				$reflection = reset($tmp);


### PR DESCRIPTION
Removed passing invalid argument to conventional reflection.
Occurs when reflection: conventional is defined in config.
