### PR TITLE
Config: normalizace interface for generated factory

### DIFF
--- a/Nette/DI/ContainerBuilder.php
+++ b/Nette/DI/ContainerBuilder.php
@@ -204,6 +204,7 @@ class ContainerBuilder extends Nette\Object
 			if (count($rc->getMethods()) !== 1 || !$rc->hasMethod('create') || $rc->getMethod('create')->isStatic()) {
 				throw new Nette\InvalidStateException("Interface $def->implement must have just one non-static method create().");
 			}
+			$def->implement = $rc->getName();
 
 			if (!$def->class && empty($def->factory->entity)) {
 				$method = $rc->getMethod('create');

--- a/tests/Nette/Config/files/config.generatedFactory.neon
+++ b/tests/Nette/Config/files/config.generatedFactory.neon
@@ -6,7 +6,7 @@ services:
 factories:
 	lorem:
 		class: Lorem
-		implement: ILoremFactory
+		implement: \ILoremFactory
 
 	article:
 		create: Article(%title%)


### PR DESCRIPTION
Autowire breaks, when the interface for factory is written with absolute name.
