### PR TITLE
Database: fix strange PHP bug [Closes #845]

### DIFF
--- a/Nette/Database/Table/GroupedSelection.php
+++ b/Nette/Database/Table/GroupedSelection.php
@@ -165,7 +165,7 @@ class GroupedSelection extends Selection
 			$this->sqlBuilder->setLimit($limit, NULL);
 			$refData = array();
 			$offset = array();
-			foreach ($this->rows as $key => $row) {
+			foreach ((array) $this->rows as $key => $row) {
 				$ref = & $refData[$row[$this->column]];
 				$skip = & $offset[$row[$this->column]];
 				if ($limit === NULL || $rows <= 1 || (count($ref) < $limit && $skip >= $this->sqlBuilder->getOffset())) {


### PR DESCRIPTION
This is done by some weird php bug. After couple of hours of debugging (with xdebug) I do not know why this is happending. Another possible solution to fix this is:

```
foreach (dump($this->rows) as $key => $row) {

// or more easily:

foreach (id($this->rows) as $key => $row) {
// where id is
function id ($a) { return $a; }
```

I was not able to extract this behaviour to open bug on php.net. Testacase for nette is located at #845.
