### PR TITLE
Forms: prevent casting error

### DIFF
--- a/Nette/Forms/Controls/BaseControl.php
+++ b/Nette/Forms/Controls/BaseControl.php
@@ -342,7 +342,7 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 	public function loadHttpData()
 	{
 		$path = explode('[', strtr(str_replace(array('[]', ']'), '', $this->getHtmlName()), '.', '_'));
-		$this->setValue(Nette\Utils\Arrays::get($this->getForm()->getHttpData(), $path, NULL));
+		$this->setValue(Nette\Utils\Arrays::get((array) $this->getForm()->getHttpData(), $path, NULL));
 	}
 
 


### PR DESCRIPTION
When the submitter is setted manually

``` php
$form->setSubmittedBy($form['send']);
```

then the `Arrays::get()` triggers casting errors.
