### PR TITLE
Debugger bluescreen: caused is not wrapped anymore

### DIFF
--- a/Nette/Diagnostics/templates/bluescreen.phtml
+++ b/Nette/Diagnostics/templates/bluescreen.phtml
@@ -319,9 +319,10 @@ $counter = 0;
 
 		#netteBluescreen .caused {
 			float: right;
-			padding: .2em .5em;
+			padding: .3em .6em;
 			background: #df8075;
 			border-radius: 0 0 0 8px;
+			white-space: nowrap;
 		}
 
 		#netteBluescreen .caused a {


### PR DESCRIPTION
Debugger bluescreen: caused is not wrapped anymore
