### PR TITLE
Latte: {breakIf} & {continueIf} allow usage as pair

### DIFF
--- a/Nette/Latte/Macros/CoreMacros.php
+++ b/Nette/Latte/Macros/CoreMacros.php
@@ -60,8 +60,8 @@ class CoreMacros extends MacroSet
 		$me->addMacro('foreach', '', array($me, 'macroEndForeach'));
 		$me->addMacro('for', 'for (%node.args):', 'endfor');
 		$me->addMacro('while', 'while (%node.args):', 'endwhile');
-		$me->addMacro('continueIf', 'if (%node.args) continue');
-		$me->addMacro('breakIf', 'if (%node.args) break');
+		$me->addMacro('continueIf', array($me, 'macroBreakIf'), 'continue; endif');
+		$me->addMacro('breakIf', array($me, 'macroBreakIf'), 'break; endif');
 		$me->addMacro('first', 'if ($iterator->isFirst(%node.args)):', 'endif');
 		$me->addMacro('last', 'if ($iterator->isLast(%node.args)):', 'endif');
 		$me->addMacro('sep', 'if (!$iterator->isLast(%node.args)):', 'endif');
@@ -243,6 +243,22 @@ class CoreMacros extends MacroSet
 		} else {
 			$node->openingCode = '<?php $iterations = 0; foreach (' . $writer->formatArgs() . '): ?>';
 			$node->closingCode = '<?php $iterations++; endforeach ?>';
+		}
+	}
+
+
+
+	/**
+	 * {breakIf ...} & {continueIf ...}
+	 */
+	public function macroBreakIf(MacroNode $node, PhpWriter $writer)
+	{
+		$cmd = 'if (%node.args):';
+		if ($node->isEmpty = (substr($node->args, -1) === '/')) {
+			$node->setArgs(substr($node->args, 0, -1));
+			return $writer->write($cmd . ' ' . substr($node->name, 0, -2) . '; endif');
+		} else {
+			return $writer->write($cmd);
 		}
 	}
 

--- a/tests/Nette/Latte/expected/macros.breakif-continueif.html
+++ b/tests/Nette/Latte/expected/macros.breakif-continueif.html
@@ -1,0 +1,13 @@
+
+	John
+
+
+	John
+		Paul
+
+
+	John
+	 foo
+
+	John
+	 foo	Paul

--- a/tests/Nette/Latte/expected/macros.breakif-continueif.phtml
+++ b/tests/Nette/Latte/expected/macros.breakif-continueif.phtml
@@ -1,0 +1,36 @@
+<?php
+// prolog Nette\Latte\Macros\CoreMacros
+list($_l, $_g) = Nette\Latte\Macros\CoreMacros::initRuntime($template, 'xxx')
+;
+// prolog Nette\Latte\Macros\UIMacros
+
+// snippets support
+if (%A%}
+
+//
+// main template
+//
+?>
+
+<?php $iterations = 0; foreach ($people as $person): ?>
+	<?php if ($person == 'Mary' ): break; endif ;echo Nette\Templating\Helpers::escapeHtml($person, ENT_NOQUOTES) ?>
+
+<?php $iterations++; endforeach ?>
+
+
+<?php $iterations = 0; foreach ($people as $person): ?>
+	<?php if ($person == 'Mary' ): continue; endif ;echo Nette\Templating\Helpers::escapeHtml($person, ENT_NOQUOTES) ?>
+
+<?php $iterations++; endforeach ?>
+
+
+<?php $iterations = 0; foreach ($people as $person): ?>
+	<?php if ($person == 'Mary'): ?> foo<?php break; endif ;echo Nette\Templating\Helpers::escapeHtml($person, ENT_NOQUOTES) ?>
+
+<?php $iterations++; endforeach ?>
+
+
+<?php $iterations = 0; foreach ($people as $person): ?>
+	<?php if ($person == 'Mary'): ?> foo<?php continue; endif ;echo Nette\Templating\Helpers::escapeHtml($person, ENT_NOQUOTES) ?>
+
+<?php $iterations++; endforeach ;

--- a/tests/Nette/Latte/macros.breakif-continueif.phpt
+++ b/tests/Nette/Latte/macros.breakif-continueif.phpt
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Test: Nette\Latte\Engine: {breakIf}, {continueIf}.
+ *
+ * @author     David Grudl
+ * @package    Nette\Latte
+ * @keepTrailingSpaces
+ */
+
+use Nette\Latte,
+	Nette\Templating\FileTemplate;
+
+
+
+require __DIR__ . '/../bootstrap.php';
+
+require __DIR__ . '/Template.inc';
+
+
+
+$template = new FileTemplate(__DIR__ . '/templates/breakif-continueif.latte');
+$template->registerFilter(new Latte\Engine);
+$template->people = array('John', 'Mary', 'Paul');
+
+$path = __DIR__ . '/expected/' . basename(__FILE__, '.phpt');
+Assert::match(file_get_contents("$path.phtml"), codefix($template->compile()));
+Assert::match(file_get_contents("$path.html"), $template->__toString(TRUE));

--- a/tests/Nette/Latte/templates/breakif-continueif.latte
+++ b/tests/Nette/Latte/templates/breakif-continueif.latte
@@ -1,0 +1,19 @@
+
+{foreach $people as $person}
+	{breakIf $person == 'Mary' /}{$person}
+{/foreach}
+
+
+{foreach $people as $person}
+	{continueIf $person == 'Mary' /}{$person}
+{/foreach}
+
+
+{foreach $people as $person}
+	{breakIf $person == 'Mary'} foo{/breakIf}{$person}
+{/foreach}
+
+
+{foreach $people as $person}
+	{continueIf $person == 'Mary'} foo{/continueIf}{$person}
+{/foreach}


### PR DESCRIPTION
This implementation adds possibility to add any special code to be placed right before `breakIf` or `continueIf` macros. Like this:

``` html
{foreach $people as $person}
    {breakIf $person == 'Mary'} foo{/breakIf}{$person}
{/foreach}
```

It is inspired by #884, this can be used to solve it in some way. But I don't like it because it introduces BC break (to keep API coherent), which doesn't seem to me to be matched by benefits. So discuss, whoever likes to :).
