### PR TITLE
Excessive trimming at RobotLoader

### DIFF
--- a/Nette/Loaders/RobotLoader.php
+++ b/Nette/Loaders/RobotLoader.php
@@ -255,7 +255,7 @@ class RobotLoader extends AutoLoader
 				if (is_file("$path/netterobots.txt")) {
 					foreach (file("$path/netterobots.txt") as $s) {
 						if (preg_match('#^(?:disallow\\s*:)?\\s*(\\S+)#i', $s, $matches)) {
-							$disallow[$path . str_replace('/', DIRECTORY_SEPARATOR, rtrim('/' . ltrim($matches[1], '/'), '/'))] = TRUE;
+							$disallow[$path . str_replace('/', DIRECTORY_SEPARATOR, '/' . trim($matches[1], '/'))] = TRUE;
 						}
 					}
 				}


### PR DESCRIPTION
I was just checking how robot loader supports per directory exclusions and then found this cryptic line.

Is there a hidden performance issue with trim or is line bellow just simpler to understand?

``` php
$disallow[$path . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, trim($matches[1], '/'))] = TRUE;
```

This version keeps some of the "Aha!" moment at least for PHP beginners. **requested in pull**

``` php
$disallow[$path . str_replace('/', DIRECTORY_SEPARATOR, '/' . trim($matches[1], '/'))] = TRUE;
```
