### PR TITLE
RobotLoader is not ignoring comments in netterobots.txt

### DIFF
--- a/Nette/Loaders/RobotLoader.php
+++ b/Nette/Loaders/RobotLoader.php
@@ -254,7 +254,7 @@ class RobotLoader extends AutoLoader
 				$path = $dir->getPathname();
 				if (is_file("$path/netterobots.txt")) {
 					foreach (file("$path/netterobots.txt") as $s) {
-						if (preg_match('#^(?:disallow\\s*:)?\\s*(\\S+)#i', $s, $matches)) {
+						if (preg_match('#^(?!\#)(?:disallow\\s*:)?\\s*(\\S+)#i', $s, $matches)) {
 							$disallow[$path . str_replace('/', DIRECTORY_SEPARATOR, rtrim('/' . ltrim($matches[1], '/'), '/'))] = TRUE;
 						}
 					}

--- a/tests/Nette/Loaders/RobotLoader.phpt
+++ b/tests/Nette/Loaders/RobotLoader.phpt
@@ -44,3 +44,6 @@ Assert::false( class_exists('Disallowed4') );   // files.robots\subdir\disallowe
 Assert::false( class_exists('Disallowed5') );   // files.robots\subdir\subdir2\disallowed5\class.php
 Assert::false( class_exists('Disallowed6') );   // files.robots\subdir\subdir2\class.php
 Assert::true( class_exists('Allowed2') );       // files.robots\subdir\subdir2\allowed.php
+
+Assert::true( class_exists('ClassWithHashInPath') );
+Assert::true( class_exists('ClassWithHashInName') );

--- a/tests/Nette/Loaders/files.robots/comment/#/class.php
+++ b/tests/Nette/Loaders/files.robots/comment/#/class.php
@@ -1,0 +1,5 @@
+<?php
+
+class ClassWithHashInPath {
+
+}

--- a/tests/Nette/Loaders/files.robots/comment/#class.php
+++ b/tests/Nette/Loaders/files.robots/comment/#class.php
@@ -1,0 +1,5 @@
+<?php
+
+class ClassWithHashInName {
+
+}

--- a/tests/Nette/Loaders/files.robots/comment/netterobots.txt
+++ b/tests/Nette/Loaders/files.robots/comment/netterobots.txt
@@ -1,0 +1,2 @@
+# Just a comment nothing to disallow here especially not # directory.
+#class.php is just mentioned here and should be available via loader.


### PR DESCRIPTION
Hash and nonspace characters from begin of comment were
added to disallowed paths.

```
#name => $path/#name
# => $path/#
```
