### PR TITLE
.gitattributes: for ignoring folders when downloading from github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+tests export-ignore


### PR DESCRIPTION
Při instalaci konkrétního tagu přes Composer se nyní nebudou stahovat z githubu testy.
