### PR TITLE
Route: constructing url without url encoding

### DIFF
--- a/Nette/Application/Routers/Route.php
+++ b/Nette/Application/Routers/Route.php
@@ -407,7 +407,7 @@ class Route extends Nette\Object implements Application\IRouter
 		}
 
 		$sep = ini_get('arg_separator.input');
-		$query = http_build_query($params, '', $sep ? $sep[0] : '&');
+		$query = urldecode(http_build_query($params, '', $sep ? $sep[0] : '&'));
 		if ($query != '') { // intentionally ==
 			$url .= '?' . $query;
 		}


### PR DESCRIPTION
Libilo by se mi kdyby např.:

``` php
$this->link('default', array('filter' => array('key' => 'value')))
```

vracelo

<code>default/?filter[key]=value</code>

místo současného

<code>default/?filter%5Bkey%5D=value</code>
