### PR TITLE
Debugger: Fixed PHP Warning encoding error

### DIFF
--- a/Nette/Diagnostics/templates/bar.errors.panel.phtml
+++ b/Nette/Diagnostics/templates/bar.errors.panel.phtml
@@ -19,7 +19,7 @@ use Nette;
 <?php foreach ($data as $item => $count): list($message, $file, $line) = explode('|', $item) ?>
 <tr class="<?php echo $i++ % 2 ? 'nette-alt' : '' ?>">
 	<td class="nette-right"><?php echo $count ? "$count\xC3\x97" : '' ?></td>
-	<td><pre><?php echo htmlspecialchars($message), ' in ', Helpers::editorLink($file, $line) ?></pre></td>
+	<td><pre><?php echo htmlspecialchars(Nette\Utils\Strings::fixEncoding($message)), ' in ', Helpers::editorLink($file, $line) ?></pre></td>
 </tr>
 <?php endforeach ?>
 </table>


### PR DESCRIPTION
Debugger.warnings.html.phpt was failing on my computer. The reason is that the PHP Warning message looked like this:

```
PHP Warning: rename(..,..): Pstup byl odepen. (code: 5) 
```

As you can see there are some letters missing. In fact the encoding was corrupted which resulted in htmlspecialchars returning an empty string instead of escaped error message.
This issue is probably windows-only and also OS-localization-dependent.
