### PR TITLE
Database: Use $user instead of $username

### DIFF
--- a/Nette/Database/Connection.php
+++ b/Nette/Database/Connection.php
@@ -44,9 +44,9 @@ class Connection extends PDO
 
 
 
-	public function __construct($dsn, $username = NULL, $password = NULL, array $options = NULL, $driverClass = NULL)
+	public function __construct($dsn, $user = NULL, $password = NULL, array $options = NULL, $driverClass = NULL)
 	{
-		parent::__construct($this->dsn = $dsn, $username, $password, $options);
+		parent::__construct($this->dsn = $dsn, $user, $password, $options);
 		$this->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 		$this->setAttribute(PDO::ATTR_STATEMENT_CLASS, array('Nette\Database\Statement', array($this)));
 


### PR DESCRIPTION
```
services:
    database:
        class: Nette\Database\Connection
        arguments: [
            dsn: ...
            user: ...
            password: ...
        ]
```

Creation of Connection by this configuration doesn't work because the parameter is not $user, but $username which results to this Exception.

```
Unable to pass specified arguments to Nette\Database\Connection::__construct
```

It should be consistent with http://api.nette.org/2.1/source-Config.Extensions.NetteExtension.php.html#75.
