### PR TITLE
Presenter: fixed throwing of confusing exception

### DIFF
--- a/Nette/Application/UI/Presenter.php
+++ b/Nette/Application/UI/Presenter.php
@@ -321,7 +321,7 @@ abstract class Presenter extends Control implements Application\IPresenter
 		} catch (Nette\InvalidArgumentException $e) {}
 
 		if (isset($e) || $component === NULL) {
-			throw new BadSignalException("The signal receiver component '$this->signalReceiver' is not found.");
+			throw new BadSignalException("The signal receiver component '$this->signalReceiver' is not found.", NULL, isset($e) ? $e : NULL);
 
 		} elseif (!$component instanceof ISignalReceiver) {
 			throw new BadSignalException("The signal receiver component '$this->signalReceiver' is not ISignalReceiver implementor.");


### PR DESCRIPTION
If the InvalidArgumentException is thrown while the component is being created, the presenter throws a confusing exception "The signal receiver component is not found.". After this change the original exception will be accessible.
