### PR TITLE
Database: Selection::find() renamed to wherePrimary()

### DIFF
--- a/Nette/Database/Table/ActiveRow.php
+++ b/Nette/Database/Table/ActiveRow.php
@@ -183,7 +183,7 @@ class ActiveRow extends Nette\Object implements \IteratorAggregate, \ArrayAccess
 		}
 		return $this->table->getConnection()
 			->table($this->table->getName())
-			->find($this->getPrimary())
+			->wherePrimary($this->getPrimary())
 			->update($data);
 	}
 
@@ -197,7 +197,7 @@ class ActiveRow extends Nette\Object implements \IteratorAggregate, \ArrayAccess
 	{
 		$res = $this->table->getConnection()
 			->table($this->table->getName())
-			->find($this->getPrimary())
+			->wherePrimary($this->getPrimary())
 			->delete();
 
 		if ($res > 0 && ($signature = $this->getSignature(FALSE))) {

--- a/Nette/Database/Table/Selection.php
+++ b/Nette/Database/Table/Selection.php
@@ -243,7 +243,7 @@ class Selection extends Nette\Object implements \Iterator, \ArrayAccess, \Counta
 	public function get($key)
 	{
 		$clone = clone $this;
-		return $clone->find($key)->fetch();
+		return $clone->wherePrimary($key)->fetch();
 	}
 
 
@@ -298,11 +298,22 @@ class Selection extends Nette\Object implements \Iterator, \ArrayAccess, \Counta
 
 
 	/**
-	 * Selects by primary key.
+	 * @deprecated
+	 */
+	public function find($key)
+	{
+		trigger_error(__METHOD__ . '() is deprecated; use $selection->wherePrimary() instead.', E_USER_DEPRECATED);
+		$this->wherePrimary($key);
+	}
+
+
+
+	/**
+	 * Adds condition for primary key.
 	 * @param  mixed
 	 * @return Selection provides a fluent interface
 	 */
-	public function find($key)
+	public function wherePrimary($key)
 	{
 		if (is_array($this->primary) && Nette\Utils\Validators::isList($key)) {
 			foreach ($this->primary as $i => $primary) {

--- a/tests/Nette/Database/Table.cache.phpt
+++ b/tests/Nette/Database/Table.cache.phpt
@@ -25,7 +25,7 @@ $connection->setSelectionFactory(new Nette\Database\Table\SelectionFactory(
 
 
 // Testing Selection caching
-$bookSelection = $connection->table('book')->find(2);
+$bookSelection = $connection->table('book')->wherePrimary(2);
 switch ($driverName) {
 	case 'mysql':
 		Assert::same('SELECT * FROM `book` WHERE (`id` = ?)', $bookSelection->getSql());
@@ -40,7 +40,7 @@ $book = $bookSelection->fetch();
 $book->title;
 $book->translator;
 $bookSelection->__destruct();
-$bookSelection = $connection->table('book')->find(2);
+$bookSelection = $connection->table('book')->wherePrimary(2);
 switch ($driverName) {
 	case 'mysql':
 		Assert::same('SELECT `id`, `title`, `translator_id` FROM `book` WHERE (`id` = ?)', $bookSelection->getSql());
@@ -63,7 +63,7 @@ switch ($driverName) {
 }
 
 $bookSelection->__destruct();
-$bookSelection = $connection->table('book')->find(2);
+$bookSelection = $connection->table('book')->wherePrimary(2);
 switch ($driverName) {
 	case 'mysql':
 		Assert::same('SELECT `id`, `title`, `translator_id`, `author_id` FROM `book` WHERE (`id` = ?)', $bookSelection->getSql());
@@ -142,7 +142,7 @@ foreach ($connection->table('author') as $author) {
 
 foreach ($relatedStack as $related) {
 	$property = $related->reflection->getProperty('accessedColumns');
-	$property->setAccessible(true);
+	$property->setAccessible(TRUE);
 	// checks if instances have shared data of accessed columns
 	Assert::same(array('id', 'author_id'), array_keys((array) $property->getValue($related)));
 }

--- a/tests/Nette/Database/Table.delete().phpt
+++ b/tests/Nette/Database/Table.delete().phpt
@@ -31,4 +31,4 @@ Assert::same(3, $count);
 
 
 $book->delete();  // DELETE FROM `book` WHERE (`id` = ?)
-Assert::same(0, count($connection->table('book')->find(3)));  // SELECT * FROM `book` WHERE (`id` = ?)
+Assert::same(0, count($connection->table('book')->wherePrimary(3)));  // SELECT * FROM `book` WHERE (`id` = ?)


### PR DESCRIPTION
Solves at least 3 cases mentioned here: http://forum.nette.org/cs/7706-api-pro-nette-database-table-selection#p58424
