### PR TITLE
Removed is_file function call from NetteLoader

### DIFF
--- a/Nette/Loaders/NetteLoader.php
+++ b/Nette/Loaders/NetteLoader.php
@@ -118,8 +118,8 @@ class NetteLoader extends AutoLoader
 			Nette\Utils\LimitedScope::load(NETTE_DIR . $this->list[$type] . '.php', TRUE);
 			self::$count++;
 
-		}/**/ elseif (substr($type, 0, 6) === 'Nette\\' && is_file($file = NETTE_DIR . strtr(substr($type, 5), '\\', '/') . '.php')) {
-			Nette\Utils\LimitedScope::load($file, TRUE);
+		}/**/ elseif (substr($type, 0, 6) === 'Nette\\') {
+			Nette\Utils\LimitedScope::load(NETTE_DIR . strtr(substr($type, 5), '\\', '/') . '.php', TRUE);
 			self::$count++;
 		}/**/
 	}


### PR DESCRIPTION
The purpose of this commit is **speed**. I think the is_file is not neccessary here. I've tried XHProf today and according to its results there were about 90 calls of the is_file function from NetteLoader and those calls took about 10ms in total (out of 200ms to load the entire page). That's a little too much in my opinion.

Can someone other confirm this?
