### PR TITLE
Forms: allow adding errors in onValidate event

### DIFF
--- a/Nette/Forms/Container.php
+++ b/Nette/Forms/Container.php
@@ -144,10 +144,10 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 	 */
 	public function validate()
 	{
-		$this->onValidate($this);
 		foreach ($this->getControls() as $control) {
 			$control->validate();
 		}
+		$this->onValidate($this);
 		$this->validated = TRUE;
 	}
 

--- a/tests/Nette/Forms/Container.validate().phpt
+++ b/tests/Nette/Forms/Container.validate().phpt
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Test: Nette\Forms\Container::validate().
+ *
+ * @author     Filip Procházka
+ * @package    Nette\Forms
+ */
+
+use Nette\Forms\Form;
+use Nette\Forms\Container;
+
+
+
+require __DIR__ . '/../bootstrap.php';
+
+$form = new Form();
+$form->addText('name', 'Text:', 10)->addRule($form::NUMERIC);
+$form->onValidate[] = function (Container $container) {
+	$container['name']->addError('just fail');
+};
+
+$form->setValues(array('name' => "invalid*input"));
+$form->validate();
+
+Assert::same(array(
+	'Please enter a numeric value.',
+	'just fail',
+), $form['name']->getErrors());
+
+


### PR DESCRIPTION
When you add errors in `Container::$onValidate` to concrete control, they [are cleared by rules validation](http://api.nette.org/2.1/source-Forms.Controls.BaseControl.php.html#582) in next step. By inverting the order, message from `onValidate` will be appended and preserved.

context: http://forum.nette.org/cs/13619-callback-na-validaciu-vs-validacne-pravidla#p97290
