### PR TITLE
tests: preserve *.sh EOL always as LF [Closes #947]

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 .gitignore export-ignore
 .travis.yml export-ignore
 tests export-ignore
+*.sh eol=lf


### PR DESCRIPTION
Shell scripts EOL will be LF no matter what core.autocrlf is.
