### PR TITLE
Template: allow to override helpers

### DIFF
--- a/Nette/Templating/Template.php
+++ b/Nette/Templating/Template.php
@@ -208,7 +208,7 @@ class Template extends Nette\Object implements ITemplate
 	 */
 	public function registerHelperLoader($callback)
 	{
-		$this->helperLoaders[] = new Nette\Callback($callback);
+		array_unshift($this->helperLoaders, new Nette\Callback($callback));
 		return $this;
 	}
 

--- a/tests/Nette/Templating/Template.helpersOverride.phpt
+++ b/tests/Nette/Templating/Template.helpersOverride.phpt
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Test: Nette\Templating\Template helpers override.
+ *
+ * @author     Filip Procházka
+ * @package    Nette\Templating
+ */
+
+use Nette\Templating\Template;
+
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+class MyHelpers
+{
+
+	public static function loader($helper)
+	{
+		if (method_exists(__CLASS__, $helper)) {
+			return new Nette\Callback(__CLASS__, $helper);
+		}
+	}
+
+
+
+	public static function date($s)
+	{
+		Notes::add(__METHOD__);
+		return Nette\DateTime::from($s)->format('Y-m-d');
+	}
+
+}
+
+
+
+$template = new Template();
+$template->registerHelperLoader('Nette\Templating\Helpers::loader');
+$template->registerHelperLoader('MyHelpers::loader');
+
+
+Assert::same( '1978-01-23', $template->date(new \Datetime('Mon, 23 Jan 1978 10:00:00 GMT'), 'd.m.Y') );
+Assert::same( array('MyHelpers::date'), Notes::fetch() );


### PR DESCRIPTION
Currently, Latte allows the user to override macro, the same (or similar) should work for helpers.
