### PR TITLE
Implemented possibility of helpers for "control" macro

### DIFF
--- a/Nette/Latte/Macros/UIMacros.php
+++ b/Nette/Latte/Macros/UIMacros.php
@@ -375,7 +375,7 @@ if (!empty($_control->snippetMode)) {
 		return ($name[0] === '$' ? "if (is_object($name)) \$_ctrl = $name; else " : '')
 			. '$_ctrl = $_control->getComponent(' . $name . '); '
 			. 'if ($_ctrl instanceof Nette\Application\UI\IRenderable) $_ctrl->validateControl(); '
-			. "\$_ctrl->$method($param)";
+			. ($node->modifiers === '' ? "\$_ctrl->$method($param)" : $writer->write("ob_start(); \$_ctrl->$method($param); echo %modify(ob_get_clean())"));
 	}
 
 

--- a/tests/Nette/Latte/UIMacros.control.phpt
+++ b/tests/Nette/Latte/UIMacros.control.phpt
@@ -19,10 +19,11 @@ UIMacros::install($compiler);
 
 // {control ...}
 Assert::match( '<?php %a% $_control->getComponent("form"); %a%->render() ?>',  $compiler->expandMacro('control', 'form', '')->openingCode );
-Assert::match( '<?php %a% $_control->getComponent("form"); %a%->render() ?>',  $compiler->expandMacro('control', 'form', 'filter')->openingCode );
+Assert::match( '<?php %a% $_control->getComponent("form"); %a%->render(); echo $template->filter(%a%) ?>',  $compiler->expandMacro('control', 'form', 'filter')->openingCode );
 Assert::match( '<?php if (is_object($form)) %a% else %a% $_control->getComponent($form); %a%->render() ?>',  $compiler->expandMacro('control', '$form', '')->openingCode );
 Assert::match( '<?php %a% $_control->getComponent("form"); %a%->renderType() ?>',  $compiler->expandMacro('control', 'form:type', '')->openingCode );
 Assert::match( '<?php %a% $_control->getComponent("form"); %a%->{"render$type"}() ?>',  $compiler->expandMacro('control', 'form:$type', '')->openingCode );
 Assert::match( '<?php %a% $_control->getComponent("form"); %a%->renderType(\'param\') ?>',  $compiler->expandMacro('control', 'form:type param', '')->openingCode );
 Assert::match( '<?php %a% $_control->getComponent("form"); %a%->renderType(array(\'param\' => 123)) ?>',  $compiler->expandMacro('control', 'form:type param => 123', '')->openingCode );
 Assert::match( '<?php %a% $_control->getComponent("form"); %a%->renderType(array(\'param\' => 123)) ?>',  $compiler->expandMacro('control', 'form:type, param => 123', '')->openingCode );
+Assert::match( '<?php %a% $_control->getComponent("form"); %a%->render(); echo $template->striptags(%a%) ?>',  $compiler->expandMacro('control', 'form', 'striptags')->openingCode );


### PR DESCRIPTION
It can be used in this way

``` smarty
{control title|striptags}
```

instead of

``` smarty
{block|striptags}{control title}{/block}
```

Is there any reason why it should not be in Nette?
