### PR TITLE
Tests: uncommented and repaired assert of helper for link macro

### DIFF
--- a/tests/Nette/Latte/UIMacros.link.phpt
+++ b/tests/Nette/Latte/UIMacros.link.phpt
@@ -20,7 +20,7 @@ UIMacros::install($compiler);
 
 // {link ...}
 Assert::same( '<?php echo $_control->link("p") ?>',  $compiler->expandMacro('link', 'p', '')->openingCode );
-/*Assert::same( '<?php echo ($template->filter$_control->link("p")) ?>',  $compiler->expandMacro('link', 'p', 'filter')->openingCode );*/
+Assert::same( '<?php echo $template->filter($_control->link("p")) ?>',  $compiler->expandMacro('link', 'p', 'filter')->openingCode );
 Assert::same( '<?php echo $_control->link("p:a") ?>',  $compiler->expandMacro('link', 'p:a', '')->openingCode );
 Assert::same( '<?php echo $_control->link($dest) ?>',  $compiler->expandMacro('link', '$dest', '')->openingCode );
 Assert::same( '<?php echo $_control->link($p:$a) ?>',  $compiler->expandMacro('link', '$p:$a', '')->openingCode );


### PR DESCRIPTION
I do not see any reason why this test assert was commented and not updated.
