### PR TITLE
Database: removed refetching all columns on ActiveRow::toArray() (BC break!)

### DIFF
--- a/Nette/Database/Table/ActiveRow.php
+++ b/Nette/Database/Table/ActiveRow.php
@@ -84,7 +84,6 @@ class ActiveRow implements \IteratorAggregate, IRow
 	 */
 	public function toArray()
 	{
-		$this->accessColumn(NULL);
 		return $this->data;
 	}
 
@@ -216,7 +215,6 @@ class ActiveRow implements \IteratorAggregate, IRow
 
 	public function getIterator()
 	{
-		$this->accessColumn(NULL);
 		return new \ArrayIterator($this->data);
 	}
 

--- a/Nette/Database/Table/Selection.php
+++ b/Nette/Database/Table/Selection.php
@@ -649,7 +649,7 @@ class Selection extends Nette\Object implements \Iterator, IRowContainer, \Array
 
 	/**
 	 * @internal
-	 * @param  string|NULL column name or (NULL to reload all columns & disable columns cache)
+	 * @param  string  column name
 	 * @param  bool
 	 */
 	public function accessColumn($key, $selectColumn = TRUE)
@@ -658,25 +658,14 @@ class Selection extends Nette\Object implements \Iterator, IRowContainer, \Array
 			return;
 		}
 
-		if ($key === NULL) {
-			$this->accessedColumns = FALSE;
-			$currentKey = key((array) $this->data);
-		} elseif ($this->accessedColumns !== FALSE) {
+		if ($this->accessedColumns !== FALSE) {
 			$this->accessedColumns[$key] = $selectColumn;
 		}
 
-		if ($selectColumn && !$this->sqlBuilder->getSelect() && $this->previousAccessedColumns && ($key === NULL || !isset($this->previousAccessedColumns[$key]))) {
+		if ($selectColumn && !$this->sqlBuilder->getSelect() && $this->previousAccessedColumns && !isset($this->previousAccessedColumns[$key])) {
 			$this->previousAccessedColumns = FALSE;
 			$this->emptyResultSet();
 			$this->dataRefreshed = TRUE;
-
-			if ($key === NULL) {
-				// we need to move iterator in resultset
-				$this->execute();
-				while (key($this->data) !== $currentKey) {
-					next($this->data);
-				}
-			}
 		}
 	}
 

--- a/tests/Nette/Database/Table.cache.rows.phpt
+++ b/tests/Nette/Database/Table.cache.rows.phpt
@@ -47,22 +47,6 @@ Assert::equal(array(
 
 
 
-$bookSelection = $connection->table('book')->order('id');
-$book = $bookSelection->fetch();
-$book->author_id;
-$bookSelection->__destruct();
-
-$bookSelection = $connection->table('book')->order('id');
-$books = array();
-$books[] = $bookSelection->fetch();
-$books[] = $bookSelection->fetch()->toArray();
-$books[] = $bookSelection->fetch()->toArray();
-Assert::equal(1, $books[0]['id']);
-Assert::equal(2, $books[1]['id']);
-Assert::equal(3, $books[2]['id']);
-
-
-
 $row = $connection->table('author')->insert(array(
 	'id' => 14,
 	'name' => 'Eddard Stark',


### PR DESCRIPTION
Removed some magic ported from NotORM.
Some discussion: http://forum.nette.org/cs/13703-mozna-chyba-v-cachovani-sloupcu-u-dotazu-v-nette-database
Correct workaroudn is to use `->select('*')` to get all columns. Othrwise in current state is impossible to iterate only over fetched columns.
