### PR TITLE
Latte: implemented new macro {snippetRunner}

### DIFF
--- a/tests/Nette/Latte/UIMacros.renderSnippets.phpt
+++ b/tests/Nette/Latte/UIMacros.renderSnippets.phpt
@@ -19,29 +19,30 @@ class InnerControl extends Nette\Application\UI\Control
 {
 	public function render()
 	{
-		$template = new Nette\Templating\Template;
+		$template = new Nette\Templating\FileTemplate;
 		$template->registerFilter(new Latte\Engine);
 		$template->_presenter = $this->getPresenter();
 		$template->_control = $this;
-		$template->setSource(<<<EOD
-			Hello {snippet test}world{/snippet}!
-EOD
-		);
+		$template->say = 'Hello';
+		$template->setFile(__DIR__ . '/templates/snippet-included.latte');
 		$template->render();
 	}
 }
 
-class MultiControl extends Nette\Application\UI\Presenter
+class TestPresenter extends Nette\Application\UI\Presenter
 {
 	private $payload;
 	function getPayload()
 	{
 		return $this->payload;
 	}
-	function createComponentMulti()
+	function emptyPayload()
 	{
 		$this->payload = new stdClass;
-		return new Nette\Application\UI\Multiplier(function($name) {
+	}
+	function createComponentMulti()
+	{
+		return new Nette\Application\UI\Multiplier(function() {
 			$control = new InnerControl();
 			$control->invalidateControl();
 			return $control;
@@ -49,21 +50,50 @@ class MultiControl extends Nette\Application\UI\Presenter
 	}
 	public function render()
 	{
-		$template = new Nette\Templating\Template;
+		$template = new Nette\Templating\FileTemplate;
 		$template->registerFilter(new Latte\Engine);
 		$template->_control = $this;
+		$template->setFile(__DIR__ . '/templates/snippet-include.latte');
 		$template->render();
 	}
 }
 
 
-$control = new MultiControl;
-$control['multi-1'];
+$control = new TestPresenter;
 $control->snippetMode = true;
+
+
+
+$control->emptyPayload();
+$control->invalidateControl();
+$control['multi-1']->invalidateControl();
+$control->render();
+Tester\Assert::equal((object) array(
+	'snippets' => array(
+		'snippet--hello' => 'Hello',
+		'snippet--include' => "<p>Included file #3 (A, B)</p>\n",
+		'snippet--array-1' => 'Value 1',
+		'snippet--array-2' => 'Value 2',
+		'snippet--array-3' => 'Value 3',
+		'snippet--includeSay' => 'Hello include snippet',
+		'snippet-multi-1-includeSay' => 'Hello',
+	),
+), $control->payload);
+
+
+
+$control->emptyPayload();
+$control->validateControl();
+$control['multi-1']->validateControl();
+$control->invalidateControl('hello');
+$control->invalidateControl('array');
 $control->render();
 
-Assert::equal((object) array(
-   'snippets' => array(
-      'snippet-multi-1-test' => 'world',
-   ),
+Tester\Assert::equal((object) array(
+	'snippets' => array(
+		'snippet--hello' => 'Hello',
+		'snippet--array-1' => 'Value 1',
+		'snippet--array-2' => 'Value 2',
+		'snippet--array-3' => 'Value 3',
+	),
 ), $control->payload);

--- a/tests/Nette/Latte/templates/snippet-include.latte
+++ b/tests/Nette/Latte/templates/snippet-include.latte
@@ -1,0 +1,15 @@
+{snippet hello}Hello{/snippet} world!
+
+{snippet include}
+	{include include3.latte localvar => 'A', hello => 'B'}
+{/snippet}
+
+{snippetRunner array}
+	{foreach [1, 2, 3] as $id}
+		{snippet array-$id}Value {$id}{/snippet}
+	{/foreach}
+{/snippetRunner}
+
+{snippetRunner}
+	{include snippet-included.latte say => 'Hello include snippet'}
+{/snippetRunner}

--- a/tests/Nette/Latte/templates/snippet-included.latte
+++ b/tests/Nette/Latte/templates/snippet-included.latte
@@ -1,0 +1,1 @@
+{snippet includeSay}{$say}{/snippet}


### PR DESCRIPTION
Adds ability to run some part of template without catching the output. Really useful with dynamic snippets. 
- adds ability to run dynamic snippets
- adds ability to run include with snippets

Discussion http://forum.nette.org/cs/5713-snippety-a-inkludovana-sablona#p73830 - see some requests for rebasing etc, it's really needed behaviour.

Also, see how it's possible to hack this without snipperRunner: https://github.com/nextras/datagrid/blob/3f1370e1b4b86c668d2f6cbcb48dca643337597f/Nextras/Datagrid/Datagrid.latte#L187-L189
