### PR TITLE
Made possible to create a class which inherits from SmtpMailer

### DIFF
--- a/Nette/Mail/SmtpMailer.php
+++ b/Nette/Mail/SmtpMailer.php
@@ -107,7 +107,7 @@ class SmtpMailer extends Nette\Object implements IMailer
 	 * Connects and authenticates to SMTP server.
 	 * @return void
 	 */
-	private function connect()
+	protected function connect()
 	{
 		$this->connection = @fsockopen( // intentionally @
 			($this->secure === 'ssl' ? 'ssl://' : '') . $this->host,
@@ -146,7 +146,7 @@ class SmtpMailer extends Nette\Object implements IMailer
 	 * Disconnects from SMTP server.
 	 * @return void
 	 */
-	private function disconnect()
+	protected function disconnect()
 	{
 		fclose($this->connection);
 		$this->connection = NULL;
@@ -161,7 +161,7 @@ class SmtpMailer extends Nette\Object implements IMailer
 	 * @param  string  error message
 	 * @return void
 	 */
-	private function write($line, $expectedCode = NULL, $message = NULL)
+	protected function write($line, $expectedCode = NULL, $message = NULL)
 	{
 		fwrite($this->connection, $line . Message::EOL);
 		if ($expectedCode && !in_array((int) $this->read(), (array) $expectedCode)) {
@@ -175,7 +175,7 @@ class SmtpMailer extends Nette\Object implements IMailer
 	 * Reads response from server.
 	 * @return string
 	 */
-	private function read()
+	protected function read()
 	{
 		$s = '';
 		while (($line = fgets($this->connection, 1e3)) != NULL) { // intentionally ==


### PR DESCRIPTION
I needed to create an database queue mailer. In order to do that I created a class which inherits from SmtpMailer. I defined my own send() method but I also needed to use methods defined in SmtpMailer. They are private now so I was forced to copy them manually. It would be nice if they were protected so I can use them in SmtpMailer descendants.
