### PR TITLE
Macro {layout} throws CompileException with its name

### DIFF
--- a/Nette/Latte/Macros/UIMacros.php
+++ b/Nette/Latte/Macros/UIMacros.php
@@ -194,13 +194,13 @@ if (!empty($_control->snippetMode)) {
 	public function macroExtends(MacroNode $node, PhpWriter $writer)
 	{
 		if (!$node->args) {
-			throw new CompileException("Missing destination in {extends}");
+			throw new CompileException('Missing destination in {' . $node->name . '}');
 		}
 		if (!empty($node->parentNode)) {
-			throw new CompileException("{extends} must be placed outside any macro.");
+			throw new CompileException('{' . $node->name . '} must be placed outside any macro.');
 		}
 		if ($this->extends !== NULL) {
-			throw new CompileException("Multiple {extends} declarations are not allowed.");
+			throw new CompileException('Multiple {' . $node->name . '} declarations are not allowed.');
 		}
 		if ($node->args === 'none') {
 			$this->extends = 'FALSE';


### PR DESCRIPTION
When you make mistake with `{layout}` macro, in `CompileException` you are told that there is mistake with `{extends}` macro. If `{layout}` macro is not ment to be deprecated, exception should speak about `{layout}` rather than `{extends}`.
