### PR TITLE
Debugger bar: fixed page bottom gap caused by debug bar

### DIFF
--- a/Nette/Diagnostics/templates/bar.phtml
+++ b/Nette/Diagnostics/templates/bar.phtml
@@ -38,6 +38,12 @@ use Nette;
 		display: block;
 	}
 
+	body #nette-debug {
+		position: absolute;
+		bottom: 0;
+		right: 0;
+	}
+
 	#nette-debug * {
 		font: inherit;
 		color: inherit;


### PR DESCRIPTION
Fixing this at the bottom of page.

![nette_debug_bar_line](https://f.cloud.github.com/assets/284263/377799/4cf3b98e-a4ee-11e2-8368-1bf907f2ae98.png)

It does not change appearance or behaviour. Tested Fx, Chrome, Opera, IE10.
