### PR TITLE
Scheme is optional

### DIFF
--- a/Nette/Http/Url.php
+++ b/Nette/Http/Url.php
@@ -342,7 +342,12 @@ class Url extends Nette\FreezableObject
 	 */
 	public function getAbsoluteUrl()
 	{
-		return $this->scheme . '://' . $this->getAuthority() . $this->path
+		$url = '//';
+		if($this->scheme != '') {
+			$url = $this->scheme . '://';
+		}
+
+		return  $url . $this->getAuthority() . $this->path
 			. ($this->query === '' ? '' : '?' . $this->query)
 			. ($this->fragment === '' ? '' : '#' . $this->fragment);
 	}


### PR DESCRIPTION
Scheme is optional according to RFC3986 4.2, therefore URL may begin with two slashes.
See http://www.ietf.org/rfc/rfc3986.txt
