### PR TITLE
Database: added multi-inserts support for Sqlite

### DIFF
--- a/Nette/Database/Drivers/SqliteDriver.php
+++ b/Nette/Database/Drivers/SqliteDriver.php
@@ -274,7 +274,7 @@ class SqliteDriver extends Nette\Object implements Nette\Database\ISupplementalD
 	 */
 	public function isSupported($item)
 	{
-		return FALSE;
+		return $item === self::REQUIRE_INSERT_AS_SELECT;
 	}
 
 }

--- a/Nette/Database/ISupplementalDriver.php
+++ b/Nette/Database/ISupplementalDriver.php
@@ -23,7 +23,8 @@ use Nette;
 interface ISupplementalDriver
 {
 	const SUPPORT_SEQUENCE = 'sequence',
-		SUPPORT_SELECT_UNGROUPED_COLUMNS = 'ungrouped_cols';
+		SUPPORT_SELECT_UNGROUPED_COLUMNS = 'ungrouped_cols',
+		REQUIRE_INSERT_AS_SELECT = 'insert_as_select';
 
 	/**
 	 * Delimites identifier for use in a SQL statement.

--- a/Nette/Database/SqlPreprocessor.php
+++ b/Nette/Database/SqlPreprocessor.php
@@ -37,8 +37,11 @@ class SqlPreprocessor extends Nette\Object
 	/** @var int */
 	private $counter;
 
-	/** @var string values|assoc|multi */
+	/** @var string values|assoc|multi|select|union */
 	private $arrayMode;
+
+	/** @var array */
+	private $arrayModes;
 
 
 
@@ -46,6 +49,16 @@ class SqlPreprocessor extends Nette\Object
 	{
 		$this->connection = $connection;
 		$this->driver = $connection->getSupplementalDriver();
+
+		$this->arrayModes = array(
+			'INSERT' => $this->driver->isSupported(ISupplementalDriver::REQUIRE_INSERT_AS_SELECT) ? 'select' : 'values',
+			'REPLACE' => 'values',
+			'UPDATE' => 'assoc',
+			'WHERE' => 'and',
+			'HAVING' => 'and',
+			'ORDER BY' => 'order',
+			'GROUP BY' => 'order',
+		);
 	}
 
 
@@ -95,16 +108,7 @@ class SqlPreprocessor extends Nette\Object
 			return $this->formatValue($this->params[$this->counter++]);
 
 		} else { // command
-			static $cmds = array(
-				'INSERT' => 'values',
-				'REPLACE' => 'values',
-				'UPDATE' => 'assoc',
-				'WHERE' => 'and',
-				'HAVING' => 'and',
-				'ORDER BY' => 'order',
-				'GROUP BY' => 'order',
-			);
-			$this->arrayMode = $cmds[strtoupper($m)];
+			$this->arrayMode = $this->arrayModes[strtoupper($m)];
 			return $m;
 		}
 	}
@@ -148,6 +152,9 @@ class SqlPreprocessor extends Nette\Object
 				foreach ($value as $v) {
 					$vx[] = $this->formatValue($v);
 				}
+				if ($this->arrayMode === 'union') {
+					return implode(' ', $vx);
+				}
 				return implode(', ', $vx);
 
 			} elseif ($this->arrayMode === 'values') { // (key, key, ...) VALUES (value, value, ...)
@@ -157,6 +164,14 @@ class SqlPreprocessor extends Nette\Object
 					$vx[] = $this->formatValue($v);
 				}
 				return '(' . implode(', ', $kx) . ') VALUES (' . implode(', ', $vx) . ')';
+
+			} elseif ($this->arrayMode === 'select') { // (key, key, ...) SELECT value, value, ...
+				$this->arrayMode = 'union';
+				foreach ($value as $k => $v) {
+					$kx[] = $this->driver->delimite($k);
+					$vx[] = $this->formatValue($v);
+				}
+				return '(' . implode(', ', $kx) . ') SELECT ' . implode(', ', $vx);
 
 			} elseif ($this->arrayMode === 'assoc') { // key=value, key=value, ...
 				foreach ($value as $k => $v) {
@@ -169,6 +184,12 @@ class SqlPreprocessor extends Nette\Object
 					$vx[] = $this->formatValue($v);
 				}
 				return '(' . implode(', ', $vx) . ')';
+
+			} elseif ($this->arrayMode === 'union') { // UNION SELECT value, value, ...
+				foreach ($value as $k => $v) {
+					$vx[] = $this->formatValue($v);
+				}
+				return 'UNION ALL SELECT ' . implode(', ', $vx);
 
 			} elseif ($this->arrayMode === 'and') { // (key [operator] value) AND ...
 				foreach ($value as $k => $v) {

--- a/tests/Nette/Database/SqlPreprocessor.phpt
+++ b/tests/Nette/Database/SqlPreprocessor.phpt
@@ -105,7 +105,7 @@ list($sql, $params) = $preprocessor->process(array('INSERT INTO author',
 
 switch ($driverName) {
 	case 'sqlite':
-		Assert::same( reformat("INSERT INTO author ([name], [born]) VALUES ('Catelyn Stark', 1320966000)"), $sql );
+		Assert::same( "INSERT INTO author ([name], [born]) SELECT 'Catelyn Stark', 1320966000", $sql );
 		break;
 	default:
 		Assert::same( reformat("INSERT INTO author ([name], [born]) VALUES ('Catelyn Stark', '2011-11-11 00:00:00')"), $sql );
@@ -121,7 +121,7 @@ list($sql, $params) = $preprocessor->process(array('INSERT INTO author', array(
 
 switch ($driverName) {
 	case 'sqlite':
-		Assert::same( reformat("INSERT INTO author ([name], [born]) VALUES ('Catelyn Stark', 1320966000), ('Sansa Stark', 1636585200)"), $sql );
+		Assert::same( "INSERT INTO author ([name], [born]) SELECT 'Catelyn Stark', 1320966000 UNION ALL SELECT 'Sansa Stark', 1636585200", $sql );
 		break;
 	default:
 		Assert::same( reformat("INSERT INTO author ([name], [born]) VALUES ('Catelyn Stark', '2011-11-11 00:00:00'), ('Sansa Stark', '2021-11-11 00:00:00')"), $sql );
@@ -144,5 +144,11 @@ list($sql, $params) = $preprocessor->process(array('INSERT INTO author ? ON DUPL
 	array('web' => 'http://nette.org', 'name' => 'Dave Lister'),
 ));
 
-Assert::same( reformat("INSERT INTO author ([id], [name]) VALUES (12, 'John Doe') ON DUPLICATE KEY UPDATE [web]='http://nette.org', [name]='Dave Lister'"), $sql );
+switch ($driverName) {
+	case 'sqlite':
+		Assert::same( "INSERT INTO author ([id], [name]) SELECT 12, 'John Doe' ON DUPLICATE KEY UPDATE [web]='http://nette.org', [name]='Dave Lister'", $sql );
+		break;
+	default:
+		Assert::same( reformat("INSERT INTO author ([id], [name]) VALUES (12, 'John Doe') ON DUPLICATE KEY UPDATE [web]='http://nette.org', [name]='Dave Lister'"), $sql );
+}
 Assert::same( array(), $params );

--- a/tests/Nette/Database/Table.insert().multi.phpt
+++ b/tests/Nette/Database/Table.insert().multi.phpt
@@ -11,9 +11,6 @@
 
 require __DIR__ . '/connect.inc.php'; // create $connection
 
-if ($driverName === 'sqlite') {
-	Tester\Helpers::skip('Sqlite does not support multi-inserts.');
-}
 Nette\Database\Helpers::loadFromFile($connection, __DIR__ . "/files/{$driverName}-nette_test1.sql");
 
 


### PR DESCRIPTION
This is a shortest way I found to add multi-insert support for Sqlite. Disadvantage is that simple INSERTs are translated as SELECT too.

I tryed more inserts in one query, but second one is ignored.
`INSERT INTO tab VALUES (1); INSERT INTO tab VALUES (2);`
