### PR TITLE
NetteExtension: can generate @property annotations on SystemContainer

### DIFF
--- a/Nette/DI/Extensions/NetteExtension.php
+++ b/Nette/DI/Extensions/NetteExtension.php
@@ -430,6 +430,17 @@ class NetteExtension extends Nette\DI\CompilerExtension
 				$initialize->addBody('$this->getService(?);', array($name));
 			}
 		}
+
+		if (!empty($config['container']['accessors'])) {
+			$definitions = $container->definitions;
+			ksort($definitions);
+			foreach ($definitions as $name => $def) {
+				if ($def->shared && Nette\PhpGenerator\Helpers::isIdentifier($name)) {
+					$type = $def->implement ?: $def->class;
+					$class->addDocument("@property $type \$$name");
+				}
+			}
+		}
 	}
 
 


### PR DESCRIPTION
NetteExtension now generates `@property` annotations on `SystemContainer`. This can be disabled in config.neon

```
nette:
    container:
        accessors: off
```
