### PR TITLE
DI\Helpers: fixed namespace resolution in getInjectProperties()

### DIFF
--- a/Nette/DI/Helpers.php
+++ b/Nette/DI/Helpers.php
@@ -161,7 +161,7 @@ final class Helpers
 
 			} elseif (!class_exists($type) && !interface_exists($type)) {
 				if ($type[0] !== '\\') {
-					$type = $class->getNamespaceName() . '\\' . $type;
+					$type = $property->getDeclaringClass()->getNamespaceName() . '\\' . $type;
 				}
 				if (!class_exists($type) && !interface_exists($type)) {
 					throw new Nette\InvalidStateException("Please use a fully qualified name of class/interface in @var annotation at $property property. Class '$type' cannot be found.");

--- a/tests/Nette/DI/Helpers.getInjectProperties().phpt
+++ b/tests/Nette/DI/Helpers.getInjectProperties().phpt
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Test: Nette\DI\Helpers::getInjectProperties()
+ *
+ * @author     Jan Tvrdík
+ * @package    Nette\DI
+ */
+
+namespace A
+{
+	class AClass
+	{
+		/** @var AInjected @inject */
+		public $varA;
+
+		/** @var B\BInjected @inject */
+		public $varB;
+
+		/** @var \A\AInjected @inject */
+		public $varC;
+
+		/** @var AInjected */
+		public $varD;
+
+		/** @var AInjected @inject */
+		protected $varE;
+	}
+
+	class AInjected
+	{
+
+	}
+}
+
+namespace A\B
+{
+	class BClass extends \A\AClass
+	{
+		/** @var BInjected @inject */
+		public $varF;
+	}
+
+	class BInjected
+	{
+
+	}
+}
+
+namespace
+{
+	use Nette\DI\Helpers;
+	use Nette\Reflection\ClassType;
+
+	require __DIR__ . '/../bootstrap.php';
+
+
+
+	$refA = ClassType::from('A\AClass');
+	$refB = ClassType::from('A\B\BClass');
+
+	Assert::same( array(
+		'varA' => 'A\AInjected',
+		'varB' => 'A\B\BInjected',
+		'varC' => '\A\AInjected',
+	), Helpers::getInjectProperties($refA) );
+
+	Assert::same( array(
+		'varF' => 'A\B\BInjected',
+		'varA' => 'A\AInjected',
+		'varB' => 'A\B\BInjected',
+		'varC' => '\A\AInjected',
+	), Helpers::getInjectProperties($refB) );
+}


### PR DESCRIPTION
I have just replaced all method injections with property injections in [nette/addons.nette.org](https://github.com/nette/addons.nette.org) and found out that the namespace resolution is broken because it resolves the FQN based on the current class and not the class which actually declared the property.
