### PR TITLE
Forms: validation data as valid JSON

### DIFF
--- a/Nette/Forms/Controls/BaseControl.php
+++ b/Nette/Forms/Controls/BaseControl.php
@@ -423,10 +423,7 @@ abstract class BaseControl extends Nette\ComponentModel\Component implements ICo
 		}
 
 		$rules = self::exportRules($this->rules);
-		$rules = substr(Nette\Utils\Json::encode($rules), 1, -1);
-		$rules = preg_replace('#"([a-z0-9_]+)":#i', '$1:', $rules);
-		$rules = preg_replace('#(?<!\\\\)"(?!:[^a-z])([^\\\\\',]*)"#i', "'$1'", $rules);
-		$control->data('nette-rules', $rules ? $rules : NULL);
+		$control->data('nette-rules', $rules ? Nette\Utils\Json::encode($rules) : NULL);
 
 		return $control;
 	}

--- a/client-side/netteForms.js
+++ b/client-side/netteForms.js
@@ -70,7 +70,7 @@ Nette.getValue = function(elem) {
  * Validates form element against given rules.
  */
 Nette.validateControl = function(elem, rules, onlyCheck) {
-	rules = rules || eval('[' + (elem.getAttribute('data-nette-rules') || '') + ']');
+	rules = rules || Nette.parseRules(elem);
 	for (var id = 0, len = rules.length; id < len; id++) {
 		var rule = rules[id], op = rule.op.match(/(~)?([^?]+)/);
 		rule.neg = op[1];
@@ -270,7 +270,7 @@ Nette.toggleForm = function(form, firsttime) {
  * Process toggles on form element.
  */
 Nette.toggleControl = function(elem, rules, topSuccess, firsttime) {
-	rules = rules || eval('[' + (elem.getAttribute('data-nette-rules') || '') + ']');
+	rules = rules || Nette.parseRules(elem);
 	var has = false, __hasProp = Object.prototype.hasOwnProperty, handler = function() {
 		Nette.toggleForm(elem.form);
 	};
@@ -317,6 +317,17 @@ Nette.toggleControl = function(elem, rules, topSuccess, firsttime) {
 		}
 	}
 	return has;
+};
+
+
+Nette.parseRules = function (elem) {
+	var rules = elem.getAttribute('data-nette-rules') || '[]';
+
+	if (rules.substr(0, 1) !== '[') {
+		return eval('[' + rules + ']'); // backward compatibility
+	}
+
+	return window.JSON && window.JSON.parse ? JSON.parse(rules) : eval(rules);
 };
 
 

--- a/tests/Nette/Forms/Forms.example.001.expect
+++ b/tests/Nette/Forms/Forms.example.001.expect
@@ -8,13 +8,13 @@
 <tr class="required">
 	<th><label class="required" for="frm-name">Your name:</label></th>
 
-	<td><input type="text" class="text" name="name" id="frm-name" required="required" data-nette-rules="{op:':filled',msg:'Enter your name'}" value="John Doe " /></td>
+	<td><input type="text" class="text" name="name" id="frm-name" required="required" data-nette-rules='[{"op":":filled","msg":"Enter your name"}]' value="John Doe " /></td>
 </tr>
 
 <tr class="required">
 	<th><label class="required" for="frm-age">Your age:</label></th>
 
-	<td><input type="text" class="text" name="age" id="frm-age" required="required" data-nette-rules="{op:':filled',msg:'Enter your age'},{op:':integer',msg:'Age must be numeric value'},{op:':range',msg:'Age must be in range from 10 to 100',arg:[10,100]}" value="" />
+	<td><input type="text" class="text" name="age" id="frm-age" required="required" data-nette-rules='[{"op":":filled","msg":"Enter your age"},{"op":":integer","msg":"Age must be numeric value"},{"op":":range","msg":"Age must be in range from 10 to 100","arg":[10,100]}]' value="" />
 
 	<span class="error">
 		Enter your age
@@ -31,7 +31,7 @@
 <tr>
 	<th><label for="frm-email">Email:</label></th>
 
-	<td><input type="text" class="text" name="email" id="frm-email" data-nette-rules="{op:':filled',rules:[{op:':email',msg:'Incorrect email address'}],control:'email'}" data-nette-empty-value="&#64;" value="&#64;" /></td>
+	<td><input type="text" class="text" name="email" id="frm-email" data-nette-rules='[{"op":":filled","rules":[{"op":":email","msg":"Incorrect email address"}],"control":"email"}]' data-nette-empty-value="&#64;" value="&#64;" /></td>
 </tr>
 </table>
 </fieldset>
@@ -43,7 +43,7 @@
 <tr>
 	<th>&nbsp;</th>
 
-	<td><input type="checkbox" name="send" id="frm-send" data-nette-rules="{op:':equal',rules:[],control:'send',toggle:{sendBox:true},arg:true}" checked="checked" /><label for="frm-send">Ship to address</label></td>
+	<td><input type="checkbox" name="send" id="frm-send" data-nette-rules='[{"op":":equal","rules":[],"control":"send","toggle":{"sendBox":true},"arg":true}]' checked="checked" /><label for="frm-send">Ship to address</label></td>
 </tr>
 </table>
 
@@ -58,7 +58,7 @@
 <tr>
 	<th><label for="frm-city">City:</label></th>
 
-	<td><input type="text" class="text" name="city" id="frm-city" data-nette-rules="{op:':equal',rules:[{op:':filled',msg:'Enter your shipping address'}],control:'send',arg:true}" value="" />
+	<td><input type="text" class="text" name="city" id="frm-city" data-nette-rules='[{"op":":equal","rules":[{"op":":filled","msg":"Enter your shipping address"}],"control":"send","arg":true}]' value="" />
 
 	<span class="error">
 		Enter your shipping address
@@ -69,7 +69,7 @@
 <tr>
 	<th><label for="frm-country">Country:</label></th>
 
-	<td><select name="country" id="frm-country" data-nette-rules="{op:':equal',rules:[{op:':filled',msg:'Select your country'}],control:'send',arg:true}"><option value="">Select your country</option><optgroup label="Europe"><option value="CZ">Czech Republic</option><option value="SK">Slovakia</option><option value="GB">United Kingdom</option></optgroup><option value="CA">Canada</option><option value="US">United States</option><option value="?">other</option></select>
+	<td><select name="country" id="frm-country" data-nette-rules='[{"op":":equal","rules":[{"op":":filled","msg":"Select your country"}],"control":"send","arg":true}]'><option value="">Select your country</option><optgroup label="Europe"><option value="CZ">Czech Republic</option><option value="SK">Slovakia</option><option value="GB">United Kingdom</option></optgroup><option value="CA">Canada</option><option value="US">United States</option><option value="?">other</option></select>
 
 	<span class="error">
 		Select your country
@@ -93,13 +93,13 @@
 <tr class="required">
 	<th><label class="required" for="frm-password">Choose password:</label></th>
 
-	<td><input type="password" class="text" name="password" id="frm-password" required="required" data-nette-rules="{op:':filled',msg:'Choose your password'},{op:':minLength',msg:'The password is too short: it must be at least 3 characters',arg:3}" /></td>
+	<td><input type="password" class="text" name="password" id="frm-password" required="required" data-nette-rules='[{"op":":filled","msg":"Choose your password"},{"op":":minLength","msg":"The password is too short: it must be at least 3 characters","arg":3}]' /></td>
 </tr>
 
 <tr>
 	<th><label for="frm-password2">Reenter password:</label></th>
 
-	<td><input type="password" class="text" name="password2" id="frm-password2" data-nette-rules="{op:':valid',rules:[{op:':filled',msg:'Reenter your password'},{op:':equal',msg:'Passwords do not match',arg:{control:'password'}}],control:'password'}" />
+	<td><input type="password" class="text" name="password2" id="frm-password2" data-nette-rules='[{"op":":valid","rules":[{"op":":filled","msg":"Reenter your password"},{"op":":equal","msg":"Passwords do not match","arg":{"control":"password"}}],"control":"password"}]' />
 
 	<span class="error">
 		Reenter your password
@@ -110,7 +110,7 @@
 <tr>
 	<th><label for="frm-avatar">Picture:</label></th>
 
-	<td><input type="file" class="text" name="avatar" id="frm-avatar" data-nette-rules="{op:':filled',rules:[{op:':image',msg:'Uploaded file is not image'}],control:'avatar'}" /></td>
+	<td><input type="file" class="text" name="avatar" id="frm-avatar" data-nette-rules='[{"op":":filled","rules":[{"op":":image","msg":"Uploaded file is not image"}],"control":"avatar"}]' /></td>
 </tr>
 
 <tr>

--- a/tests/Nette/Forms/Forms.example.004.expect
+++ b/tests/Nette/Forms/Forms.example.004.expect
@@ -7,13 +7,13 @@
 
 	<dt><label class="required" for="frm-name">Your name:</label></dt>
 
-	<dd><input type="text" class="text" name="name" id="frm-name" required="required" data-nette-rules="{op:':filled',msg:'Enter your name'}" value="John Doe " /> •</dd>
+	<dd><input type="text" class="text" name="name" id="frm-name" required="required" data-nette-rules='[{"op":":filled","msg":"Enter your name"}]' value="John Doe " /> •</dd>
 
 
 
 	<dt><label class="required" for="frm-age">Your age:</label></dt>
 
-	<dd class="odd"><input type="text" class="text" name="age" id="frm-age" required="required" data-nette-rules="{op:':filled',msg:'Enter your age'},{op:':integer',msg:'Age must be numeric value'},{op:':range',msg:'Age must be in range from 10 to 100',arg:[10,100]}" value="9.9" /> •
+	<dd class="odd"><input type="text" class="text" name="age" id="frm-age" required="required" data-nette-rules='[{"op":":filled","msg":"Enter your age"},{"op":":integer","msg":"Age must be numeric value"},{"op":":range","msg":"Age must be in range from 10 to 100","arg":[10,100]}]' value="9.9" /> •
 
 	<span class="error">
 		Age must be numeric value
@@ -35,7 +35,7 @@
 
 	<dt><label for="frm-email">Email:</label></dt>
 
-	<dd class="odd"><input type="text" class="text" name="email" id="frm-email" data-nette-rules="{op:':filled',rules:[{op:':email',msg:'Incorrect email address'}],control:'email'}" data-nette-empty-value="&#64;" value="&#64;" /></dd>
+	<dd class="odd"><input type="text" class="text" name="email" id="frm-email" data-nette-rules='[{"op":":filled","rules":[{"op":":email","msg":"Incorrect email address"}],"control":"email"}]' data-nette-empty-value="&#64;" value="&#64;" /></dd>
 
 </dl>
 
@@ -47,7 +47,7 @@
 
 	<dt></dt>
 
-	<dd><input type="checkbox" name="send" id="frm-send" data-nette-rules="{op:':equal',rules:[],control:'send',toggle:{sendBox:true},arg:true}" /><label for="frm-send">Ship to address</label></dd>
+	<dd><input type="checkbox" name="send" id="frm-send" data-nette-rules='[{"op":":equal","rules":[],"control":"send","toggle":{"sendBox":true},"arg":true}]' /><label for="frm-send">Ship to address</label></dd>
 
 </dl>
 
@@ -62,13 +62,13 @@
 
 	<dt><label for="frm-city">City:</label></dt>
 
-	<dd><input type="text" class="text" name="city" id="frm-city" data-nette-rules="{op:':equal',rules:[{op:':filled',msg:'Enter your shipping address'}],control:'send',arg:true}" value="Troubsko" /></dd>
+	<dd><input type="text" class="text" name="city" id="frm-city" data-nette-rules='[{"op":":equal","rules":[{"op":":filled","msg":"Enter your shipping address"}],"control":"send","arg":true}]' value="Troubsko" /></dd>
 
 
 
 	<dt><label for="frm-country">Country:</label></dt>
 
-	<dd class="odd"><select name="country" id="frm-country" data-nette-rules="{op:':equal',rules:[{op:':filled',msg:'Select your country'}],control:'send',arg:true}"><option value="">Select your country</option><optgroup label="Europe"><option value="CZ">Czech Republic</option><option value="SK">Slovakia</option><option value="GB">United Kingdom</option></optgroup><option value="CA">Canada</option><option value="US">United States</option><option value="?">other</option></select></dd>
+	<dd class="odd"><select name="country" id="frm-country" data-nette-rules='[{"op":":equal","rules":[{"op":":filled","msg":"Select your country"}],"control":"send","arg":true}]'><option value="">Select your country</option><optgroup label="Europe"><option value="CZ">Czech Republic</option><option value="SK">Slovakia</option><option value="GB">United Kingdom</option></optgroup><option value="CA">Canada</option><option value="US">United States</option><option value="?">other</option></select></dd>
 
 </dl>
 </div>
@@ -81,7 +81,7 @@
 
 	<dt><label class="required" for="frm-password">Choose password:</label></dt>
 
-	<dd><input type="password" class="text" name="password" id="frm-password" required="required" data-nette-rules="{op:':filled',msg:'Choose your password'},{op:':minLength',msg:'The password is too short: it must be at least 3 characters',arg:3}" /> • <small>(at least 3 characters)</small>
+	<dd><input type="password" class="text" name="password" id="frm-password" required="required" data-nette-rules='[{"op":":filled","msg":"Choose your password"},{"op":":minLength","msg":"The password is too short: it must be at least 3 characters","arg":3}]' /> • <small>(at least 3 characters)</small>
 
 	<span class="error">
 		The password is too short: it must be at least 3 characters
@@ -92,7 +92,7 @@
 
 	<dt><label for="frm-password2">Reenter password:</label></dt>
 
-	<dd class="odd"><input type="password" class="text" name="password2" id="frm-password2" data-nette-rules="{op:':valid',rules:[{op:':filled',msg:'Reenter your password'},{op:':equal',msg:'Passwords do not match',arg:{control:'password'}}],control:'password'}" /></dd>
+	<dd class="odd"><input type="password" class="text" name="password2" id="frm-password2" data-nette-rules='[{"op":":valid","rules":[{"op":":filled","msg":"Reenter your password"},{"op":":equal","msg":"Passwords do not match","arg":{"control":"password"}}],"control":"password"}]' /></dd>
 
 
 

--- a/tests/Nette/Forms/Forms.example.005.expect
+++ b/tests/Nette/Forms/Forms.example.005.expect
@@ -4,7 +4,7 @@
 <tr>
 	<th><label for="frm-num1">Multiple of 8:</label></th>
 
-	<td><input type="text" class="text" name="num1" id="frm-num1" data-nette-rules="{op:'myValidator',msg:'First number must be 8 multiple',arg:8}" value="5" />
+	<td><input type="text" class="text" name="num1" id="frm-num1" data-nette-rules='[{"op":"myValidator","msg":"First number must be 8 multiple","arg":8}]' value="5" />
 
 	<span class="error">
 		First number must be 8 multiple
@@ -15,7 +15,7 @@
 <tr>
 	<th><label for="frm-num2">Not multiple of 5:</label></th>
 
-	<td><input type="text" class="text" name="num2" id="frm-num2" data-nette-rules="{op:'~myValidator',msg:'Second number must not be 5 multiple',arg:5}" value="5" />
+	<td><input type="text" class="text" name="num2" id="frm-num2" data-nette-rules='[{"op":"~myValidator","msg":"Second number must not be 5 multiple","arg":5}]' value="5" />
 
 	<span class="error">
 		Second number must not be 5 multiple

--- a/tests/Nette/Forms/Forms.example.007.expect
+++ b/tests/Nette/Forms/Forms.example.007.expect
@@ -5,11 +5,11 @@
 		<table>
 		<tr class="required">
 			<th><label class="required" for="frm-name">Your name:</label></th>
-			<td><input type="text" class="text" name="name" id="frm-name" required="required" data-nette-rules="{op:':filled',msg:'Enter your name'}" value="John Doe " cols="35" /></td>
+			<td><input type="text" class="text" name="name" id="frm-name" required="required" data-nette-rules='[{"op":":filled","msg":"Enter your name"}]' value="John Doe " cols="35" /></td>
 		</tr>
 		<tr class="required">
 			<th><label class="required" for="frm-age">Your age:</label></th>
-			<td><input type="text" class="text" name="age" id="frm-age" required="required" data-nette-rules="{op:':filled',msg:'Enter your age'},{op:':integer',msg:'Age must be numeric value'},{op:':range',msg:'Age must be in range from 10 to 100',arg:[10,100]}" value="  12 " cols="5" /></td>
+			<td><input type="text" class="text" name="age" id="frm-age" required="required" data-nette-rules='[{"op":":filled","msg":"Enter your age"},{"op":":integer","msg":"Age must be numeric value"},{"op":":range","msg":"Age must be in range from 10 to 100","arg":[10,100]}]' value="  12 " cols="5" /></td>
 		</tr>
 		<tr>
 			<th><label>Your gender:</label></th>
@@ -17,7 +17,7 @@
 		</tr>
 		<tr>
 			<th><label for="frm-email">Email:</label></th>
-			<td><input type="text" class="text" name="email" id="frm-email" data-nette-rules="{op:':filled',rules:[{op:':email',msg:'Incorrect email address'}],control:'email'}" data-nette-empty-value="&#64;" value="&#64;" cols="35" /></td>
+			<td><input type="text" class="text" name="email" id="frm-email" data-nette-rules='[{"op":":filled","rules":[{"op":":email","msg":"Incorrect email address"}],"control":"email"}]' data-nette-empty-value="&#64;" value="&#64;" cols="35" /></td>
 		</tr>
 		</table>
 	</fieldset>
@@ -26,7 +26,7 @@
 	<fieldset>
 		<legend>Shipping address</legend>
 
-		<p><input type="checkbox" name="send" id="frm-send" data-nette-rules="{op:':equal',rules:[],control:'send',toggle:{sendBox:true},arg:true}" /><label for="frm-send">Ship to address</label></p>
+		<p><input type="checkbox" name="send" id="frm-send" data-nette-rules='[{"op":":equal","rules":[],"control":"send","toggle":{"sendBox":true},"arg":true}]' /><label for="frm-send">Ship to address</label></p>
 
 		<table id="sendBox">
 		<tr>
@@ -35,11 +35,11 @@
 		</tr>
 		<tr class="required">
 			<th><label for="frm-city">City:</label></th>
-			<td><input type="text" class="text" name="city" id="frm-city" data-nette-rules="{op:':equal',rules:[{op:':filled',msg:'Enter your shipping address'}],control:'send',arg:true}" value="" cols="35" /></td>
+			<td><input type="text" class="text" name="city" id="frm-city" data-nette-rules='[{"op":":equal","rules":[{"op":":filled","msg":"Enter your shipping address"}],"control":"send","arg":true}]' value="" cols="35" /></td>
 		</tr>
 		<tr class="required">
 			<th><label for="frm-country">Country:</label></th>
-			<td><select name="country" id="frm-country" data-nette-rules="{op:':equal',rules:[{op:':filled',msg:'Select your country'}],control:'send',arg:true}"><option value="">Select your country</option><optgroup label="Europe"><option value="CZ" selected="selected">Czech Republic</option><option value="SK">Slovakia</option><option value="GB">United Kingdom</option></optgroup><option value="CA">Canada</option><option value="US">United States</option><option value="?">other</option></select></td>
+			<td><select name="country" id="frm-country" data-nette-rules='[{"op":":equal","rules":[{"op":":filled","msg":"Select your country"}],"control":"send","arg":true}]'><option value="">Select your country</option><optgroup label="Europe"><option value="CZ" selected="selected">Czech Republic</option><option value="SK">Slovakia</option><option value="GB">United Kingdom</option></optgroup><option value="CA">Canada</option><option value="US">United States</option><option value="?">other</option></select></td>
 		</tr>
 		</table>
 	</fieldset>
@@ -51,11 +51,11 @@
 		<table>
 		<tr class="required">
 			<th><label class="required" for="frm-password">Choose password:</label></th>
-			<td><input type="password" class="text" name="password" id="frm-password" required="required" data-nette-rules="{op:':filled',msg:'Choose your password'},{op:':minLength',msg:'The password is too short: it must be at least 3 characters',arg:3}" cols="20" /></td>
+			<td><input type="password" class="text" name="password" id="frm-password" required="required" data-nette-rules='[{"op":":filled","msg":"Choose your password"},{"op":":minLength","msg":"The password is too short: it must be at least 3 characters","arg":3}]' cols="20" /></td>
 		</tr>
 		<tr class="required">
 			<th><label for="frm-password2">Reenter password:</label></th>
-			<td><input type="password" class="text" name="password2" id="frm-password2" data-nette-rules="{op:':valid',rules:[{op:':filled',msg:'Reenter your password'},{op:':equal',msg:'Passwords do not match',arg:{control:'password'}}],control:'password'}" cols="20" /></td>
+			<td><input type="password" class="text" name="password2" id="frm-password2" data-nette-rules='[{"op":":valid","rules":[{"op":":filled","msg":"Reenter your password"},{"op":":equal","msg":"Passwords do not match","arg":{"control":"password"}}],"control":"password"}]' cols="20" /></td>
 		</tr>
 		<tr>
 			<th><label for="frm-avatar">Picture:</label></th>

--- a/tests/Nette/Forms/Forms.example.008.expect
+++ b/tests/Nette/Forms/Forms.example.008.expect
@@ -5,25 +5,25 @@
 <tr>
 	<th><label for="frm-query">Search:</label></th>
 
-	<td><input type="search" autofocus="autofocus" name="query" id="frm-query" data-nette-rules="{op:':pattern',msg:'Must be alphanumeric string',arg:'[a-z0-9]+'}" pattern="[a-z0-9]+" value="" /></td>
+	<td><input type="search" autofocus="autofocus" name="query" id="frm-query" data-nette-rules='[{"op":":pattern","msg":"Must be alphanumeric string","arg":"[a-z0-9]+"}]' pattern="[a-z0-9]+" value="" /></td>
 </tr>
 
 <tr>
 	<th><label for="frm-count">Number of results:</label></th>
 
-	<td><input type="number" name="count" id="frm-count" data-nette-rules="{op:':integer',msg:'Must be numeric value'},{op:':range',msg:'Must be in range from 1 to 100',arg:[1,100]}" max="100" min="1" value="10" /></td>
+	<td><input type="number" name="count" id="frm-count" data-nette-rules='[{"op":":integer","msg":"Must be numeric value"},{"op":":range","msg":"Must be in range from 1 to 100","arg":[1,100]}]' max="100" min="1" value="10" /></td>
 </tr>
 
 <tr>
 	<th><label for="frm-precision">Precision:</label></th>
 
-	<td><input type="range" name="precision" id="frm-precision" data-nette-rules="{op:':integer',msg:'Precision must be numeric value'},{op:':range',msg:'Precision must be in range from 0 to 100',arg:[0,100]}" max="100" min="0" value="50" /></td>
+	<td><input type="range" name="precision" id="frm-precision" data-nette-rules='[{"op":":integer","msg":"Precision must be numeric value"},{"op":":range","msg":"Precision must be in range from 0 to 100","arg":[0,100]}]' max="100" min="0" value="50" /></td>
 </tr>
 
 <tr>
 	<th><label for="frm-email">Send to email:</label></th>
 
-	<td><input type="email" autocomplete="off" placeholder="Optional, but Recommended" name="email" id="frm-email" data-nette-rules="{op:':filled',rules:[{op:':email',msg:'Incorrect email address'}],control:'email'}" value="" /></td>
+	<td><input type="email" autocomplete="off" placeholder="Optional, but Recommended" name="email" id="frm-email" data-nette-rules='[{"op":":filled","rules":[{"op":":email","msg":"Incorrect email address"}],"control":"email"}]' value="" /></td>
 </tr>
 
 <tr>

--- a/tests/Nette/Forms/Rules.formatMessage.phpt
+++ b/tests/Nette/Forms/Rules.formatMessage.phpt
@@ -20,7 +20,7 @@ $form->addText('email', 'Email')
 	->addRule(Form::EMAIL, '%label %value is invalid [field %name]')
 	->setDefaultValue('xyz');
 
-Assert::match("%A%data-nette-rules=\"{op:':email',msg:'Email %value is invalid [field email]'}\"%A%", $form->__toString(TRUE));
+Assert::match('%A%data-nette-rules=\'[{"op":":email","msg":"Email %value is invalid [field email]"}]\'%A%', $form->__toString(TRUE));
 
 $form->validate();
 


### PR DESCRIPTION
See thread on forum: http://forum.nette.org/cs/14286-nevalidni-json-u-form-rules

I think it makes sense to have a valid JSON there. The used JSON.parse is [supported](http://caniuse.com/#search=json.parse) by all major browsers and by IE since version 8.
Lets discuss it here or on the forum if needed.
