### PR TITLE
RFC: allow tranform Db\ResultSet to Db\Table\ResultSet

### DIFF
--- a/Nette/Database/Table/BaseResultSet.php
+++ b/Nette/Database/Table/BaseResultSet.php
@@ -1,0 +1,363 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (http://nette.org)
+ *
+ * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
+ *
+ * For the full copyright and license information, please view
+ * the file license.txt that was distributed with this source code.
+ */
+
+namespace Nette\Database\Table;
+
+use Nette,
+	Nette\Caching\Cache,
+	Nette\Caching\IStorage,
+	Nette\Database\Connection,
+	Nette\Database\IReflection,
+	Nette\Database\ISupplementalDriver;
+
+
+
+/**
+ * Table row result set.
+ * ResultSet is based on the great library NotORM http://www.notorm.com written by Jakub Vrana.
+ *
+ * @author     Jan Skrasek
+ *
+ * @property-read string $sql
+ */
+abstract class BaseResultSet extends Nette\Object implements \Iterator, IRowContainer, \Countable
+{
+	/** @var Connection */
+	protected $connection;
+
+	/** @var IReflection */
+	protected $reflection;
+
+	/** @var Cache */
+	protected $cache;
+
+	/** @var string table name */
+	protected $name;
+
+	/** @var string primary key field name */
+	protected $primary;
+
+	/** @var string|bool primary column sequence name, FALSE for autodetection */
+	protected $primarySequence = FALSE;
+
+	/** @var IRow[] data read from database in [primary key => IRow] format */
+	protected $rows;
+
+	/** @var IRow[] modifiable data in [primary key => IRow] format */
+	protected $data;
+
+	/** @var mixed */
+	protected $refCache;
+
+	/** @var mixed cache array of Selection and GroupedSelection prototypes */
+	protected $globalRefCache;
+
+	/** @var array of primary key values */
+	protected $keys = array();
+
+
+
+	/**
+	 * Creates table row result set.
+	 * @param  string
+	 * @param  Connection
+	 * @param  IReflection
+	 * @param  IStorage
+	 */
+	public function __construct($table, Connection $connection, IReflection $reflection, IStorage $cacheStorage = NULL)
+	{
+		$this->name = $table;
+		$this->connection = $connection;
+		$this->reflection = $reflection;
+		$this->cache = $cacheStorage ? new Nette\Caching\Cache($cacheStorage, 'Nette.Database.' . md5($connection->getDsn())) : NULL;
+		$this->primary = $reflection->getPrimary($table);
+	}
+
+
+
+	/**
+	 * @return Connection
+	 */
+	public function getConnection()
+	{
+		return $this->connection;
+	}
+
+
+
+	/**
+	 * @return IReflection
+	 */
+	public function getDatabaseReflection()
+	{
+		return $this->reflection;
+	}
+
+
+
+	/**
+	 * @return string
+	 */
+	public function getName()
+	{
+		return $this->name;
+	}
+
+
+
+	/**
+	 * @return string|array
+	 */
+	public function getPrimary()
+	{
+		if ($this->primary === NULL) {
+			throw new \LogicException("Table \"{$this->name}\" does not have a primary key.");
+		}
+		return $this->primary;
+	}
+
+
+
+	/**
+	 * @return string
+	 */
+	public function getPrimarySequence()
+	{
+		if ($this->primarySequence === FALSE) {
+			$this->primarySequence = NULL;
+
+			$primary = $this->getPrimary();
+			$driver = $this->connection->getSupplementalDriver();
+			if ($driver->isSupported(ISupplementalDriver::SUPPORT_SEQUENCE)) {
+				foreach ($driver->getColumns($this->name) as $column) {
+					if ($column['name'] === $primary) {
+						$this->primarySequence = $column['vendor']['sequence'];
+						break;
+					}
+				}
+			}
+		}
+
+		return $this->primarySequence;
+	}
+
+
+
+	/**
+	 * @param  string
+	 * @return Selection provides a fluent interface
+	 */
+	public function setPrimarySequence($sequence)
+	{
+		$this->primarySequence = $sequence;
+		return $this;
+	}
+
+
+
+	/**
+	 * @return string
+	 */
+	abstract public function getSql();
+
+
+
+
+	/********************* quick access ****************d*g**/
+
+
+
+	/**
+	 * @inheritDoc
+	 */
+	public function fetch()
+	{
+		$this->execute();
+		$return = current($this->data);
+		next($this->data);
+		return $return;
+	}
+
+
+
+	/**
+	 * @inheritDoc
+	 */
+	public function fetchPairs($key, $value = NULL)
+	{
+		$return = array();
+		foreach ($this as $row) {
+			$return[is_object($row[$key]) ? (string) $row[$key] : $row[$key]] = ($value === NULL ? $row : $row[$value]);
+		}
+		return $return;
+	}
+
+
+
+	/**
+	 * @inheritDoc
+	 */
+	public function fetchAll()
+	{
+		return iterator_to_array($this);
+	}
+
+
+
+	/**
+	 * Counts number of rows.
+	 * @return int
+	 */
+	public function count()
+	{
+		$this->execute();
+		return count($this->data);
+	}
+
+
+
+	/********************* internal ****************d*g**/
+
+
+
+	abstract protected function execute();
+
+
+
+	public function createSelectionInstance($table = NULL)
+	{
+		return new Selection($this->connection, $table ?: $this->name, $this->reflection, $this->cache ? $this->cache->getStorage() : NULL);
+	}
+
+
+
+	protected function createGroupedSelectionInstance($table, $column)
+	{
+		return new GroupedSelection($table, $column, $this, $this->connection, $this->reflection, $this->cache ? $this->cache->getStorage() : NULL);
+	}
+
+
+
+	abstract protected function getSpecificCacheKey();
+
+
+
+	/********************* references ****************d*g**/
+
+
+
+	/**
+	 * Returns referenced row.
+	 * @param  string
+	 * @param  string
+	 * @param  mixed   primary key to check for $table and $column references
+	 * @return Selection or array() if the row does not exist
+	 */
+	public function getReferencedTable($table, $column, $checkPrimaryKey)
+	{
+		$referenced = & $this->refCache['referenced'][$this->getSpecificCacheKey()]["$table.$column"];
+		$selection = & $referenced['selection'];
+		$cacheKeys = & $referenced['cacheKeys'];
+		if ($selection === NULL || !isset($cacheKeys[$checkPrimaryKey])) {
+			$this->execute();
+			$cacheKeys = array();
+			foreach ($this->rows as $row) {
+				if ($row[$column] === NULL) {
+					continue;
+				}
+
+				$key = $row[$column];
+				$cacheKeys[$key] = TRUE;
+			}
+
+			if ($cacheKeys) {
+				$selection = $this->createSelectionInstance($table);
+				$selection->where($selection->getPrimary(), array_keys($cacheKeys));
+			} else {
+				$selection = array();
+			}
+		}
+
+		return $selection;
+	}
+
+
+
+	/**
+	 * Returns referencing rows.
+	 * @param  string
+	 * @param  string
+	 * @param  int primary key
+	 * @return GroupedSelection
+	 */
+	public function getReferencingTable($table, $column, $active = NULL)
+	{
+		$prototype = & $this->refCache['referencingPrototype']["$table.$column"];
+		if (!$prototype) {
+			$prototype = $this->createGroupedSelectionInstance($table, $column);
+			$prototype->where("$table.$column", array_keys((array) $this->rows));
+		}
+
+		$clone = clone $prototype;
+		$clone->setActive($active);
+		return $clone;
+	}
+
+
+
+	/********************* interface Iterator ****************d*g**/
+
+
+
+	public function rewind()
+	{
+		$this->execute();
+		$this->keys = array_keys($this->data);
+		reset($this->keys);
+	}
+
+
+
+	/** @return IRow */
+	public function current()
+	{
+		if (($key = current($this->keys)) !== FALSE) {
+			return $this->data[$key];
+		} else {
+			return FALSE;
+		}
+	}
+
+
+
+	/**
+	 * @return string row ID
+	 */
+	public function key()
+	{
+		return current($this->keys);
+	}
+
+
+
+	public function next()
+	{
+		next($this->keys);
+	}
+
+
+
+	public function valid()
+	{
+		return current($this->keys) !== FALSE;
+	}
+
+}

--- a/Nette/Database/Table/GroupedSelection.php
+++ b/Nette/Database/Table/GroupedSelection.php
@@ -11,7 +11,10 @@
 
 namespace Nette\Database\Table;
 
-use Nette;
+use Nette,
+	Nette\Caching\IStorage,
+	Nette\Database\Connection,
+	Nette\Database\IReflection;
 
 
 /**
@@ -38,15 +41,18 @@ class GroupedSelection extends Selection
 
 	/**
 	 * Creates filtered and grouped table representation.
-	 * @param  Selection  $refTable
 	 * @param  string  database table name
 	 * @param  string  joining column
+	 * @param  Selection
+	 * @param  Connection
+	 * @param  IReflection
+	 * @param  ICacheStorage|NULL
 	 */
-	public function __construct(Selection $refTable, $table, $column)
+	public function __construct($table, $column, Selection $refTable, Connection $connection, IReflection $reflection, IStorage $cacheStorage = NULL)
 	{
 		$this->refTable = $refTable;
 		$this->column = $column;
-		parent::__construct($refTable->connection, $table, $refTable->reflection, $refTable->cache ? $refTable->cache->getStorage() : NULL);
+		parent::__construct($connection, $table, $reflection, $cacheStorage);
 	}
 
 

--- a/Nette/Database/Table/GroupedSelection.php
+++ b/Nette/Database/Table/GroupedSelection.php
@@ -26,7 +26,7 @@ use Nette,
  */
 class GroupedSelection extends Selection
 {
-	/** @var Selection referenced table */
+	/** @var BaseResultSet referenced table */
 	protected $refTable;
 
 	/** @var  mixed current assigned referencing array */
@@ -48,7 +48,7 @@ class GroupedSelection extends Selection
 	 * @param  IReflection
 	 * @param  ICacheStorage|NULL
 	 */
-	public function __construct($table, $column, Selection $refTable, Connection $connection, IReflection $reflection, IStorage $cacheStorage = NULL)
+	public function __construct($table, $column, BaseResultSet $refTable, Connection $connection, IReflection $reflection, IStorage $cacheStorage = NULL)
 	{
 		$this->refTable = $refTable;
 		$this->column = $column;

--- a/Nette/Database/Table/IRow.php
+++ b/Nette/Database/Table/IRow.php
@@ -22,7 +22,7 @@ use Nette\Database;
 interface IRow extends Database\IRow
 {
 
-	function setTable(Selection $name);
+	function setTable($resultSet);
 
 	function getTable();
 

--- a/Nette/Database/Table/ResultSet.php
+++ b/Nette/Database/Table/ResultSet.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (http://nette.org)
+ *
+ * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
+ *
+ * For the full copyright and license information, please view
+ * the file license.txt that was distributed with this source code.
+ */
+
+namespace Nette\Database\Table;
+
+use Nette,
+	Nette\Caching\Cache,
+	Nette\Caching\IStorage,
+	Nette\Database,
+	Nette\Database\Connection,
+	Nette\Database\IReflection;
+
+
+
+/**
+ * Table row result set.
+ *
+ * @author     Jan Skrasek
+ */
+class ResultSet extends BaseResultSet
+{
+
+	/** @var Database\ResultSet */
+	protected $resultSet;
+
+
+
+	/**
+	 * @param  string
+	 * @param  Database\ResultSet
+	 * @param  Connection
+	 * @param  IReflection
+	 * @param  IStorage
+	 */
+	public function __construct($table, Database\ResultSet $resultSet, Connection $connection, IReflection $reflection, IStorage $cacheStorage = NULL)
+	{
+		parent::__construct($table, $connection, $reflection, $cacheStorage);
+		$this->resultSet = $resultSet;
+	}
+
+
+
+	/**
+	 * @return string
+	 */
+	public function getSql()
+	{
+		return $this->resultSet->getQueryString();
+	}
+
+
+
+	/********************* internal ****************d*g**/
+
+
+
+	protected function execute()
+	{
+		if ($this->rows !== NULL) {
+			return;
+		}
+
+
+		while ($row = $this->resultSet->fetch()) {
+			$row = new Row((array) $row, $this);
+			if ($signature = $row->getSignature(FALSE)) {
+				$this->rows[$signature] = $row;
+			} else {
+				$this->rows[] = $row;
+			}
+		}
+
+		$this->data = $this->rows;
+	}
+
+
+
+	protected function getSpecificCacheKey()
+	{
+		return spl_object_hash($this);
+	}
+
+}

--- a/Nette/Database/Table/Row.php
+++ b/Nette/Database/Table/Row.php
@@ -1,0 +1,290 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (http://nette.org)
+ *
+ * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
+ *
+ * For the full copyright and license information, please view
+ * the file license.txt that was distributed with this source code.
+ */
+
+namespace Nette\Database\Table;
+
+use Nette,
+	Nette\Database\Reflection\MissingReferenceException;
+
+
+
+/**
+ * Single row representation.
+ * ActiveRow is based on the great library NotORM http://www.notorm.com written by Jakub Vrana.
+ *
+ * @author     Jakub Vrana
+ * @author     Jan Skrasek
+ */
+class Row implements \IteratorAggregate, IRow
+{
+	/** @var BaseResultSet */
+	protected $table;
+
+	/** @var array of row data */
+	protected $data;
+
+
+
+	public function __construct(array $data, BaseResultSet $table)
+	{
+		$this->data = $data;
+		$this->setTable($table);
+	}
+
+
+
+	/**
+	 * @internal
+	 * @ignore
+	 */
+	public function setTable($resultSet)
+	{
+		if (!$resultSet instanceof BaseResultSet) {
+			throw new \LogicException('Row table must be descendant of Nette\Database\Table\BaseResultSet.');
+		}
+		$this->table = $resultSet;
+	}
+
+
+
+	/**
+	 * @internal
+	 */
+	public function getTable()
+	{
+		return $this->table;
+	}
+
+
+
+	public function __toString()
+	{
+		try {
+			return (string) $this->getPrimary();
+		} catch (\Exception $e) {
+			trigger_error("Exception in " . __METHOD__ . "(): {$e->getMessage()} in {$e->getFile()}:{$e->getLine()}", E_USER_ERROR);
+		}
+	}
+
+
+
+	/**
+	 * @return array
+	 */
+	public function toArray()
+	{
+		return $this->data;
+	}
+
+
+
+	/**
+	 * Returns primary key value.
+	 * @param  bool
+	 * @return mixed
+	 */
+	public function getPrimary($need = TRUE)
+	{
+		$primary = $this->table->getPrimary();
+		if (!is_array($primary)) {
+			if (isset($this->data[$primary])) {
+				return $this->data[$primary];
+			} elseif ($need) {
+				throw new Nette\InvalidStateException("Row does not contain primary $primary column data.");
+			} else {
+				return NULL;
+			}
+		} else {
+			$primaryVal = array();
+			foreach ($primary as $key) {
+				if (!isset($this->data[$key])) {
+					if ($need) {
+						throw new Nette\InvalidStateException("Row does not contain primary $key column data.");
+					} else {
+						return NULL;
+					}
+				}
+				$primaryVal[$key] = $this->data[$key];
+			}
+			return $primaryVal;
+		}
+	}
+
+
+
+	/**
+	 * Returns row signature (composition of primary keys)
+	 * @param  bool
+	 * @return string
+	 */
+	public function getSignature($need = TRUE)
+	{
+		return implode('|', (array) $this->getPrimary($need));
+	}
+
+
+
+	/**
+	 * Returns referenced row.
+	 * @param  string
+	 * @param  string
+	 * @return IRow or NULL if the row does not exist
+	 */
+	public function ref($key, $throughColumn = NULL)
+	{
+		if (!$throughColumn) {
+			list($key, $throughColumn) = $this->table->getDatabaseReflection()->getBelongsToReference($this->table->getName(), $key);
+		}
+
+		return $this->getReference($key, $throughColumn);
+	}
+
+
+
+	/**
+	 * Returns referencing rows.
+	 * @param  string
+	 * @param  string
+	 * @return GroupedSelection
+	 */
+	public function related($key, $throughColumn = NULL)
+	{
+		if (strpos($key, '.') !== FALSE) {
+			list($key, $throughColumn) = explode('.', $key);
+		} elseif (!$throughColumn) {
+			list($key, $throughColumn) = $this->table->getDatabaseReflection()->getHasManyReference($this->table->getName(), $key);
+		}
+
+		return $this->table->getReferencingTable($key, $throughColumn, $this[$this->table->getPrimary()]);
+	}
+
+
+
+
+	/********************* interface IteratorAggregate ****************d*g**/
+
+
+
+	public function getIterator()
+	{
+		return new \ArrayIterator($this->data);
+	}
+
+
+
+	/********************* interface ArrayAccess & magic accessors ****************d*g**/
+
+
+
+	/**
+	 * Stores value in column.
+	 * @param  string column name
+	 * @param  string value
+	 * @return void
+	 */
+	public function offsetSet($key, $value)
+	{
+		$this->__set($key, $value);
+	}
+
+
+
+	/**
+	 * Returns value of column.
+	 * @param  string column name
+	 * @return string
+	 */
+	public function offsetGet($key)
+	{
+		return $this->__get($key);
+	}
+
+
+
+	/**
+	 * Tests if column exists.
+	 * @param  string column name
+	 * @return bool
+	 */
+	public function offsetExists($key)
+	{
+		return $this->__isset($key);
+	}
+
+
+
+	/**
+	 * Removes column from data.
+	 * @param  string column name
+	 * @return void
+	 */
+	public function offsetUnset($key)
+	{
+		$this->__unset($key);
+	}
+
+
+
+	public function __set($key, $value)
+	{
+		throw new Nette\DeprecatedException('ActiveRow is read-only; use update() method instead.');
+	}
+
+
+
+	public function &__get($key)
+	{
+		if (array_key_exists($key, $this->data)) {
+			return $this->data[$key];
+		}
+
+		try {
+			list($table, $column) = $this->table->getDatabaseReflection()->getBelongsToReference($this->table->getName(), $key);
+			$referenced = $this->getReference($table, $column);
+			if ($referenced !== FALSE) {
+				return $referenced;
+			}
+		} catch(MissingReferenceException $e) {}
+
+		throw new Nette\MemberAccessException("Cannot read an undeclared column \"$key\".");
+	}
+
+
+
+	public function __isset($key)
+	{
+		if (array_key_exists($key, $this->data)) {
+			return isset($this->data[$key]);
+		}
+		return FALSE;
+	}
+
+
+
+	public function __unset($key)
+	{
+		throw new Nette\DeprecatedException('ActiveRow is read-only.');
+	}
+
+
+
+	protected function getReference($table, $column)
+	{
+		if (array_key_exists($column, $this->data)) {
+			$value = $this->data[$column];
+			$referenced = $this->table->getReferencedTable($table, $column, $value);
+			return isset($referenced[$value]) ? $referenced[$value] : NULL; // referenced row may not exist
+		}
+
+		return FALSE;
+	}
+
+}

--- a/Nette/Database/Table/Selection.php
+++ b/Nette/Database/Table/Selection.php
@@ -530,7 +530,7 @@ class Selection extends Nette\Object implements \Iterator, IRowContainer, \Array
 
 	protected function createGroupedSelectionInstance($table, $column)
 	{
-		return new GroupedSelection($this, $table, $column);
+		return new GroupedSelection($table, $column, $this, $this->connection, $this->reflection, $this->cache ? $this->cache->getStorage() : NULL);
 	}
 
 

--- a/Nette/Diagnostics/Logger.php
+++ b/Nette/Diagnostics/Logger.php
@@ -56,7 +56,8 @@ class Logger extends Nette\Object
 			$message = implode(' ', $message);
 		}
 		$message = preg_replace('#\s*\r?\n\s*#', ' ', trim($message));
-		$res = error_log($message . PHP_EOL, 3, $this->directory . '/' . strtolower($priority ?: self::INFO) . '.log');
+		$file = $this->directory . '/' . strtolower($priority ?: self::INFO) . '.log';
+		$res = (bool) file_put_contents($file, $message . PHP_EOL, FILE_APPEND | LOCK_EX);
 
 		if (($priority === self::ERROR || $priority === self::CRITICAL) && $this->email && $this->mailer
 			&& @filemtime($this->directory . '/email-sent') + $this->emailSnooze < time() // @ - file may not exist

--- a/Nette/Diagnostics/OutputDebugger.php
+++ b/Nette/Diagnostics/OutputDebugger.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (http://nette.org)
+ *
+ * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
+ *
+ * For the full copyright and license information, please view
+ * the file license.txt that was distributed with this source code.
+ */
+
+namespace Nette\Diagnostics;
+
+use Nette;
+
+
+/**
+ * @author     David Grudl
+ */
+class OutputDebugger extends Nette\Object
+{
+	const BOM = "\xEF\xBB\xBF";
+
+	/** @var array of [file, line, output] */
+	private $list = array();
+
+	/** @var string */
+	private $lastFile;
+
+
+	public static function enable()
+	{
+		$me = new static;
+		$me->start();
+	}
+
+
+	public function start()
+	{
+		foreach (get_included_files() as $file) {
+			if (fread(fopen($file, 'r'), 3) === self::BOM) {
+				$this->list[] = array($file, 1, self::BOM);
+			}
+		}
+		ob_start(array($this, 'handler'), PHP_VERSION_ID >= 50400 ? 1 : 2);
+	}
+
+
+	public function handler($s, $phase)
+	{
+		$trace = debug_backtrace(FALSE);
+		if (isset($trace[0]['file'], $trace[0]['line'])) {
+			if ($this->lastFile === $trace[0]['file']) {
+				$this->list[count($this->list) - 1][2] .= $s;
+			} else {
+				$this->list[] = array($this->lastFile = $trace[0]['file'], $trace[0]['line'], $s);
+			}
+		}
+		if ($phase === PHP_OUTPUT_HANDLER_FINAL) {
+			return $this->renderHtml();
+		}
+	}
+
+
+	private function renderHtml()
+	{
+		$res = '<style>code, pre {white-space:nowrap} a {text-decoration:none} pre {color:gray;display:inline} big {color:red}</style><code>';
+		foreach ($this->list as $item) {
+			list($file, $line, $s) = $item;
+			$res .= Helpers::editorLink($item[0], $item[1]) . ' '
+				. str_replace(self::BOM, '<big>BOM</big>', Dumper::toHtml($item[2])) . "<br>\n";
+		}
+		return $res . '</code>';
+	}
+
+}

--- a/tests/Nette/Database/Table.ResultSet.phpt
+++ b/tests/Nette/Database/Table.ResultSet.phpt
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Test: Nette\Database\Table\NativeResultSet.
+ *
+ * @author     Jan Skrasek
+ * @package    Nette\Database\Table
+ * @dataProvider? databases.ini
+ */
+
+use Tester\Assert;
+use Nette\Caching\Storages\MemoryStorage;
+use Nette\Database\Reflection\DiscoveredReflection;
+use Nette\Database\Table\ResultSet;
+
+require __DIR__ . '/connect.inc.php'; // create $connection
+
+Nette\Database\Helpers::loadFromFile($connection, __DIR__ . "/files/{$driverName}-nette_test1.sql");
+
+header('Content-type: text/html');
+Nette\Diagnostics\Debugger::enable(FALSE);
+Nette\Diagnostics\Debugger::$strictMode = TRUE;
+Nette\Database\Helpers::createDebugPanel($connection);
+Nette\Diagnostics\Debugger::$blueScreen->addPanel('Nette\Database\Diagnostics\ConnectionPanel::renderException');
+
+$cacheStorage = new MemoryStorage;
+
+
+
+$res = $connection->query('SELECT * FROM book ORDER BY id');
+$resultSet = new ResultSet('book', $res, $connection, new DiscoveredReflection($connection, $cacheStorage), $cacheStorage);
+
+$bookTags = array();
+foreach ($resultSet as $book) {
+	$bookTags[$book->title] = array(
+		'author' => $book->author->name,
+		'tags' => array(),
+	);
+
+	foreach ($book->related('book_tag') as $book_tag) {
+		$bookTags[$book->title]['tags'][] = $book_tag->tag->name;
+	}
+}
+
+Assert::same(array(
+	'1001 tipu a triku pro PHP' => array(
+		'author' => 'Jakub Vrana',
+		'tags' => array('PHP', 'MySQL'),
+	),
+	'JUSH' => array(
+		'author' => 'Jakub Vrana',
+		'tags' => array('JavaScript'),
+	),
+	'Nette' => array(
+		'author' => 'David Grudl',
+		'tags' => array('PHP'),
+	),
+	'Dibi' => array(
+		'author' => 'David Grudl',
+		'tags' => array('PHP', 'MySQL'),
+	),
+), $bookTags);


### PR DESCRIPTION
This is RFC, it's more about relationships and implementation than naming and API.

This PR will allow to run own SQL query, but you will be able to process request as it would be done by Selection.

```php
$query = $connection->query('SELECT * FROM book ORDER BY id');
$result = new ResultSet('book', $query, $connection, new DiscoveredReflection($connection, $cacheStorage), $cacheStorage);

$book = $result->fetch();
echo $book->title;
echo $book->author->title;
foreach ($book->related('book_tag') as $bookTag) {
    echo $bookTag->tag->name;
}
```