### PR TITLE
Dumper: allow custom class handlers

### DIFF
--- a/tests/Nette/Diagnostics/Dumper.addClassDumper().phpt
+++ b/tests/Nette/Diagnostics/Dumper.addClassDumper().phpt
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Test: Nette\Diagnostics\Dumper::addClassDumper()
+ *
+ * @author     Filip Procházka
+ * @package    Nette\Diagnostics
+ */
+
+use Nette\Diagnostics\Dumper;
+
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+
+class ClassDumper_Test
+{
+	public $x = array(10, NULL);
+
+	private $y = 'hello';
+
+	protected $z = 30.0;
+}
+
+class Connection
+{
+
+	public $host;
+
+	public $database;
+
+
+	public function __construct($host, $database)
+	{
+		$this->host = $host;
+		$this->database = $database;
+	}
+
+}
+
+function ClassDumper_Test_dumper (ClassDumper_Test $test) {
+	return $test->x;
+}
+
+Dumper::addClassDumper('ClassDumper_Test', 'ClassDumper_Test_dumper');
+
+function ClassDumper_Connection_dumper(Connection $db) {
+	return $db->host . ':' . $db->database;
+}
+
+Dumper::addClassDumper('Connection', 'ClassDumper_Connection_dumper');
+
+Assert::match( 'ClassDumper_Test (2)
+   0 => 10
+   1 => NULL
+', Dumper::toText(new ClassDumper_Test) );
+
+Assert::match('Connection => "localhost:nette" (15)', Dumper::toText(new Connection('localhost', 'nette')));
+
+
+function ClassDumper_Connection_bad_dumper(Connection $db) {
+	return $db; // returns object
+}
+
+Dumper::addClassDumper('Connection', 'ClassDumper_Connection_bad_dumper');
+
+Assert::exception(function () {
+	Dumper::toText(new Connection('localhost', 'nette'));
+}, 'Nette\UnexpectedValueException', 'Callback ClassDumper_Connection_bad_dumper must return scalar or array, object returned.');


### PR DESCRIPTION
I have classes, which internals are not important. Collections for example. There is a class `PersistentCollection` in Doctrine, that holds a lot of information that I don't care about (connection to database, ...) and I only care about the entities it holds. 

This would allow me to write

``` php
Nette\Diagnostics\Dumper::addClassDumper('Doctrine\ORM\PersistentCollection', function ($pc) {
    return $pc->toArray();
});
```

And have nice dumps. Compare

![persistentcollection](https://f.cloud.github.com/assets/158625/477447/3541dbac-b7e2-11e2-88e9-818d072f4454.png)

with much nicer

![persistentcollection-better](https://f.cloud.github.com/assets/158625/477436/d1ee38f2-b7e1-11e2-9d4e-f28298f7790f.png)
