### PR TITLE
Object: provide ::getClassName()

### DIFF
--- a/Nette/common/Object.php
+++ b/Nette/common/Object.php
@@ -70,6 +70,17 @@ abstract class Object
 
 
 	/**
+	 * Returns class name as a string.
+	 * @return string
+	 */
+	public /**/static/**/ function getClassName()
+	{
+		return /*5.2*get_class($this)*//**/get_called_class()/**/;
+	}
+
+
+
+	/**
 	 * Call to undefined method.
 	 * @param  string  method name
 	 * @param  array   arguments

--- a/tests/Nette/common/Object.getClassName().phpt
+++ b/tests/Nette/common/Object.getClassName().phpt
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Test: Nette\Object class name.
+ *
+ * @author     Filip Procházka
+ * @package    Nette
+ */
+
+
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+
+class TestClass extends Nette\Object
+{
+}
+
+
+$obj = new TestClass;
+Assert::same( 'TestClass', $obj->getClassName() );
+Assert::same( 'TestClass', TestClass::getClassName() );


### PR DESCRIPTION
This helper is useful for working with class names. Triggering autoloading is not a problem here, I use the class anyways.

``` php
$articles = $entityManager->getRepository(App\Article::getClassName());
$article = $articles->find(1);
```

Related:
- http://marc.info/?l=php-internals&m=123257207431054&w=2
- https://wiki.php.net/rfc/class_name_scalars

I know it's in 5.5, but let's be reasonable, how long will it take to get 5.5 supported to be able to use it in global opensource projects? Five years at least? 

Its 2013, 5.2 is dead and there are still applications dependent on it, and not even 5.4 is widenly supported.

---

Someone pointed out, that this is already "supported"

``` php
App\Article::getReflection()->getName();
```

Am I the only one, who sees this as a overkill?
