### PR TITLE
Database: PgSqlDriver reflection search in all current schemas

### DIFF
--- a/Nette/Database/Drivers/PgSqlDriver.php
+++ b/Nette/Database/Drivers/PgSqlDriver.php
@@ -124,7 +124,7 @@ class PgSqlDriver extends Nette\Object implements Nette\Database\ISupplementalDr
 				JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace
 			WHERE
 				c.relkind IN ('r', 'v')
-				AND n.nspname = current_schema()
+				AND ARRAY[n.nspname] <@ pg_catalog.current_schemas(FALSE)
 			ORDER BY
 				c.relname
 		") as $row) {
@@ -164,7 +164,7 @@ class PgSqlDriver extends Nette\Object implements Nette\Database\ISupplementalDr
 			WHERE
 				c.relkind IN ('r', 'v')
 				AND c.relname::varchar = {$this->connection->quote($table)}
-				AND n.nspname = current_schema()
+				AND ARRAY[n.nspname] <@ pg_catalog.current_schemas(FALSE)
 				AND a.attnum > 0
 				AND NOT a.attisdropped
 			ORDER BY
@@ -201,7 +201,7 @@ class PgSqlDriver extends Nette\Object implements Nette\Database\ISupplementalDr
 				JOIN pg_catalog.pg_class AS c2 ON i.indexrelid = c2.oid
 				LEFT JOIN pg_catalog.pg_attribute AS a ON c1.oid = a.attrelid AND a.attnum = ANY(i.indkey)
 			WHERE
-				n.nspname = current_schema()
+				ARRAY[n.nspname] <@ pg_catalog.current_schemas(FALSE)
 				AND c1.relkind = 'r'
 				AND c1.relname = {$this->connection->quote($table)}
 		") as $row) {
@@ -236,7 +236,7 @@ class PgSqlDriver extends Nette\Object implements Nette\Database\ISupplementalDr
 				JOIN pg_catalog.pg_attribute AS al ON al.attrelid = cl.oid AND al.attnum = co.conkey[1]
 				JOIN pg_catalog.pg_attribute AS af ON af.attrelid = cf.oid AND af.attnum = co.confkey[1]
 			WHERE
-				n.nspname = current_schema()
+				ARRAY[n.nspname] <@ pg_catalog.current_schemas(FALSE)
 				AND co.contype = 'f'
 				AND cl.relname = {$this->connection->quote($table)}
 		")->fetchAll();


### PR DESCRIPTION
Partially solves #1101.

This is without BC break. Limitations of multiple schemas using overview:
- must call `SET search_path TO schema1, schema2, schema3`
- table must be named uniquely across all schemas

Related problem (http://forum.nette.org/cs/14487-postgresql-automaticke-cmuchani-cizich-klicu)
