### PR TITLE
Database: tryDelimite strict delimiteres matching (BC break!) [Closes #819]

### DIFF
--- a/Nette/Database/Drivers/MsSqlDriver.php
+++ b/Nette/Database/Drivers/MsSqlDriver.php
@@ -21,6 +21,9 @@ use Nette;
  */
 class MsSqlDriver extends Nette\Object implements Nette\Database\ISupplementalDriver
 {
+	const LEFT_DELIMITER = '[';
+	const RIGHT_DELIMITER = ']';
+
 	/** @var Nette\Database\Connection */
 	private $connection;
 

--- a/Nette/Database/Drivers/MySqlDriver.php
+++ b/Nette/Database/Drivers/MySqlDriver.php
@@ -21,6 +21,9 @@ use Nette;
  */
 class MySqlDriver extends Nette\Object implements Nette\Database\ISupplementalDriver
 {
+	const LEFT_DELIMITER = '`';
+	const RIGHT_DELIMITER = '`';
+
 	const ERROR_ACCESS_DENIED = 1045;
 	const ERROR_DUPLICATE_ENTRY = 1062;
 	const ERROR_DATA_TRUNCATED = 1265;

--- a/Nette/Database/Drivers/OciDriver.php
+++ b/Nette/Database/Drivers/OciDriver.php
@@ -21,6 +21,9 @@ use Nette;
  */
 class OciDriver extends Nette\Object implements Nette\Database\ISupplementalDriver
 {
+	const LEFT_DELIMITER = '"';
+	const RIGHT_DELIMITER = '"';
+
 	/** @var Nette\Database\Connection */
 	private $connection;
 

--- a/Nette/Database/Drivers/OdbcDriver.php
+++ b/Nette/Database/Drivers/OdbcDriver.php
@@ -21,6 +21,9 @@ use Nette;
  */
 class OdbcDriver extends Nette\Object implements Nette\Database\ISupplementalDriver
 {
+	const LEFT_DELIMITER = '[';
+	const RIGHT_DELIMITER = ']';
+
 	/** @var Nette\Database\Connection */
 	private $connection;
 

--- a/Nette/Database/Drivers/PgSqlDriver.php
+++ b/Nette/Database/Drivers/PgSqlDriver.php
@@ -21,6 +21,9 @@ use Nette;
  */
 class PgSqlDriver extends Nette\Object implements Nette\Database\ISupplementalDriver
 {
+	const LEFT_DELIMITER = '"';
+	const RIGHT_DELIMITER = '"';
+
 	/** @var Nette\Database\Connection */
 	private $connection;
 

--- a/Nette/Database/Drivers/SqliteDriver.php
+++ b/Nette/Database/Drivers/SqliteDriver.php
@@ -21,6 +21,9 @@ use Nette;
  */
 class SqliteDriver extends Nette\Object implements Nette\Database\ISupplementalDriver
 {
+	const LEFT_DELIMITER = '[';
+	const RIGHT_DELIMITER = ']';
+
 	/** @var Nette\Database\Connection */
 	private $connection;
 

--- a/Nette/Database/Drivers/SqlsrvDriver.php
+++ b/Nette/Database/Drivers/SqlsrvDriver.php
@@ -22,6 +22,9 @@ use Nette;
  */
 class SqlsrvDriver extends Nette\Object implements Nette\Database\ISupplementalDriver
 {
+	const LEFT_DELIMITER = '[';
+	const RIGHT_DELIMITER = ']';
+
 	/** @var Nette\Database\Connection */
 	private $connection;
 

--- a/Nette/Database/Table/SqlBuilder.php
+++ b/Nette/Database/Table/SqlBuilder.php
@@ -478,7 +478,9 @@ class SqlBuilder extends Nette\Object
 	protected function tryDelimite($s)
 	{
 		$driver = $this->driver;
-		return preg_replace_callback('#(?<=[^\w`"\[]|^)[a-z_][a-z0-9_]*(?=[^\w`"(\]]|\z)#i', function($m) use ($driver) {
+		$lDelimiter = preg_quote($driver::LEFT_DELIMITER, '#');
+		$rDelimiter = preg_quote($driver::RIGHT_DELIMITER, '#');
+		return preg_replace_callback('#(?<=[^\w' . $lDelimiter . ']|^)[a-z_][a-z0-9_]*(?=[^\w(' . $rDelimiter . ']|\z)#i', function($m) use ($driver) {
 			return strtoupper($m[0]) === $m[0] ? $m[0] : $driver->delimite($m[0]);
 		}, $s);
 	}

--- a/Nette/Diagnostics/Logger.php
+++ b/Nette/Diagnostics/Logger.php
@@ -56,7 +56,8 @@ class Logger extends Nette\Object
 			$message = implode(' ', $message);
 		}
 		$message = preg_replace('#\s*\r?\n\s*#', ' ', trim($message));
-		$res = error_log($message . PHP_EOL, 3, $this->directory . '/' . strtolower($priority ?: self::INFO) . '.log');
+		$file = $this->directory . '/' . strtolower($priority ?: self::INFO) . '.log';
+		$res = (bool) file_put_contents($file, $message . PHP_EOL, FILE_APPEND | LOCK_EX);
 
 		if (($priority === self::ERROR || $priority === self::CRITICAL) && $this->email && $this->mailer
 			&& @filemtime($this->directory . '/email-sent') + $this->emailSnooze < time() // @ - file may not exist

--- a/Nette/Diagnostics/OutputDebugger.php
+++ b/Nette/Diagnostics/OutputDebugger.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (http://nette.org)
+ *
+ * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
+ *
+ * For the full copyright and license information, please view
+ * the file license.txt that was distributed with this source code.
+ */
+
+namespace Nette\Diagnostics;
+
+use Nette;
+
+
+/**
+ * @author     David Grudl
+ */
+class OutputDebugger extends Nette\Object
+{
+	const BOM = "\xEF\xBB\xBF";
+
+	/** @var array of [file, line, output] */
+	private $list = array();
+
+	/** @var string */
+	private $lastFile;
+
+
+	public static function enable()
+	{
+		$me = new static;
+		$me->start();
+	}
+
+
+	public function start()
+	{
+		foreach (get_included_files() as $file) {
+			if (fread(fopen($file, 'r'), 3) === self::BOM) {
+				$this->list[] = array($file, 1, self::BOM);
+			}
+		}
+		ob_start(array($this, 'handler'), PHP_VERSION_ID >= 50400 ? 1 : 2);
+	}
+
+
+	public function handler($s, $phase)
+	{
+		$trace = debug_backtrace(FALSE);
+		if (isset($trace[0]['file'], $trace[0]['line'])) {
+			if ($this->lastFile === $trace[0]['file']) {
+				$this->list[count($this->list) - 1][2] .= $s;
+			} else {
+				$this->list[] = array($this->lastFile = $trace[0]['file'], $trace[0]['line'], $s);
+			}
+		}
+		if ($phase === PHP_OUTPUT_HANDLER_FINAL) {
+			return $this->renderHtml();
+		}
+	}
+
+
+	private function renderHtml()
+	{
+		$res = '<style>code, pre {white-space:nowrap} a {text-decoration:none} pre {color:gray;display:inline} big {color:red}</style><code>';
+		foreach ($this->list as $item) {
+			list($file, $line, $s) = $item;
+			$res .= Helpers::editorLink($item[0], $item[1]) . ' '
+				. str_replace(self::BOM, '<big>BOM</big>', Dumper::toHtml($item[2])) . "<br>\n";
+		}
+		return $res . '</code>';
+	}
+
+}

--- a/tests/Nette/Database/SqlBuilder.tryDelimite().phpt
+++ b/tests/Nette/Database/SqlBuilder.tryDelimite().phpt
@@ -26,4 +26,3 @@ Assert::same(reformat('[hello].[world]'), $tryDelimite->invoke($sqlBuilder, 'hel
 Assert::same(reformat('[hello] [world]'), $tryDelimite->invoke($sqlBuilder, 'hello world'));
 Assert::same(reformat('HELLO([world])'), $tryDelimite->invoke($sqlBuilder, 'HELLO(world)'));
 Assert::same(reformat('hello([world])'), $tryDelimite->invoke($sqlBuilder, 'hello(world)'));
-Assert::same('[hello]', $tryDelimite->invoke($sqlBuilder, '[hello]'));


### PR DESCRIPTION
Removed support for not-delimiting strings closed by quotes. This was possible only in drivers without quote as delimiter -> !(postgre|oci).

This is BC break and at the same time SECURITY fix.
Only possible way to include strings into query is by placeholder, which is implemented for all methods two months ago. See #1003

Something like this is no longer supported.
```php
$sqlBuilder->select('DATE_FORMAT(column, "%b %d %Y")');
```
It was not also intuitive, because this didn't work:
```php
$sqlBuilder->select("DATE_FORMAT(column, '%b %d %Y')");
```

Use 
```php
$sqlBuilder->select('DATE_FORMAT(column, ?)', '%b %d %Y');
```