### PR TITLE
Added label to getControl(key) of RadioList

### DIFF
--- a/Nette/Forms/Controls/RadioList.php
+++ b/Nette/Forms/Controls/RadioList.php
@@ -157,16 +157,24 @@ class RadioList extends BaseControl
 			$label->for = $control->id .= '-' . $key;                        
 			$control->checked = (string) $key === $value;
 			$control->value = $key;
-                                                
-                        $valArray = array_slice($this->items, $key, 1);
-                        $val = $valArray[0];
+
+                        $counter=-1;
                         
-                        if ($val instanceof Html) {
-				$label->setHtml($val);
-			} else {
-				$label->setText($this->translate((string) $val));
-			}                        
-                        return array($control, $label);
+                        foreach ($this->items as $k => $val) {
+                            $counter++;
+                            
+                            if ((string) $key !== (string) $counter) {
+                                continue;
+                            }
+                            if ($val instanceof Html) {
+                                $label->setHtml($val);
+                            } 
+                            else {
+                                $label->setText($this->translate((string) $val));
+                            }                            
+                            return array($control, $label);
+                        }
+                                                           
 		}
 
 		$id = $control->id;


### PR DESCRIPTION
Now is no way to render manually radioList - there is no way how to
render label of this control. This commit adds label as second key in
array. Return for getControl(key) is now array(control, label).

Example of usage:
{foreach $form['type']->getControl() as $key => $value}
{var $html = $_form['type']->getControl($key), $input = $html[0], $label = $html[1]}
<tr>
  <td>{!$input}</td>
  <td>
   {!$label->startTag()}
   {$label->getText()}
   {!$label->endTag()}
  </td>
</tr>  
{/foreach}
