### PR TITLE
Database: previously accessed columns cache is bound with stack trace

### DIFF
--- a/Nette/Database/Table/Selection.php
+++ b/Nette/Database/Table/Selection.php
@@ -652,8 +652,11 @@ class Selection extends Nette\Object implements \Iterator, IRowContainer, \Array
 		if ($this->generalCacheKey) {
 			return $this->generalCacheKey;
 		}
-
-		return $this->generalCacheKey = md5(serialize(array(__CLASS__, $this->name, $this->sqlBuilder->getConditions())));
+		$key = array(__CLASS__, $this->name, $this->sqlBuilder->getConditions());
+		foreach (debug_backtrace(PHP_VERSION_ID >= 50306 ? DEBUG_BACKTRACE_IGNORE_ARGS : FALSE) as $item) {
+			$key[] = isset($item['file'], $item['line']) ? $item['file'] . $item['line'] : NULL;
+		};
+		return $this->generalCacheKey = md5(serialize($key));
 	}
 
 


### PR DESCRIPTION
This is just experiment and breaks current tests. 

Stack trace is used for resolution at which place of source code the query was executed. And executing query in different places usually means different usage. 

In the worst case, there will be more items in the cache, but usually the cache will perform better. Maybe we can add some limitations for recursive code.
