### PR TITLE
Forms: addText() and addPassword() deprecated third parameter $cols 

### DIFF
--- a/Nette/Forms/Container.php
+++ b/Nette/Forms/Container.php
@@ -251,10 +251,12 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 	 */
 	public function addText($name, $label = NULL, $cols = NULL, $maxLength = NULL)
 	{
+		$control = new Controls\TextInput($label, $maxLength);
 		if ($cols) {
 			trigger_error(__METHOD__ . '() third parameter $cols is deprecated.', E_USER_DEPRECATED);
+			$control->getControlPrototype()->size($cols);
 		}
-		return $this[$name] = new Controls\TextInput($label, $cols, $maxLength);
+		return $this[$name] = $control;
 	}
 
 
@@ -269,12 +271,12 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 	 */
 	public function addPassword($name, $label = NULL, $cols = NULL, $maxLength = NULL)
 	{
+		$control = new Controls\TextInput($label, $maxLength);
 		if ($cols) {
 			trigger_error(__METHOD__ . '() third parameter $cols is deprecated.', E_USER_DEPRECATED);
+			$control->getControlPrototype()->size($cols);
 		}
-		$control = new Controls\TextInput($label, $cols, $maxLength);
-		$control->setType('password');
-		return $this[$name] = $control;
+		return $this[$name] = $control->setType('password');
 	}
 
 
@@ -289,10 +291,12 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 	 */
 	public function addTextArea($name, $label = NULL, $cols = NULL, $rows = NULL)
 	{
+		$control = new Controls\TextArea($label);
 		if ($cols || $rows) {
 			trigger_error(__METHOD__ . '() parameters $cols and $rows are deprecated.', E_USER_DEPRECATED);
+			$control->getControlPrototype()->cols($cols)->rows($rows);
 		}
-		return $this[$name] = new Controls\TextArea($label, $cols, $rows);
+		return $this[$name] = $control;
 	}
 
 

--- a/Nette/Forms/Controls/TextArea.php
+++ b/Nette/Forms/Controls/TextArea.php
@@ -25,15 +25,11 @@ class TextArea extends TextBase
 
 	/**
 	 * @param  string  label
-	 * @param  int  width of the control
-	 * @param  int  height of the control in text lines
 	 */
-	public function __construct($label = NULL, $cols = NULL, $rows = NULL)
+	public function __construct($label = NULL)
 	{
 		parent::__construct($label);
 		$this->control->setName('textarea');
-		$this->control->cols = $cols;
-		$this->control->rows = $rows;
 	}
 
 

--- a/Nette/Forms/Controls/TextInput.php
+++ b/Nette/Forms/Controls/TextInput.php
@@ -26,14 +26,12 @@ class TextInput extends TextBase
 
 	/**
 	 * @param  string  label
-	 * @param  int  width of the control
 	 * @param  int  maximum number of characters the user may enter
 	 */
-	public function __construct($label = NULL, $cols = NULL, $maxLength = NULL)
+	public function __construct($label = NULL, $maxLength = NULL)
 	{
 		parent::__construct($label);
 		$this->control->type = 'text';
-		$this->control->size = $cols;
 		$this->control->maxlength = $maxLength;
 	}
 


### PR DESCRIPTION
Input length is usually defined by the CSS and this parameter becomes unnecessary. In future it can be replaced by more useful parameter, i.e. current fourth parameter $maxLength,
