### PR TITLE
Proof of Concept: Show objects in Debugger blue screen

### DIFF
--- a/Nette/Diagnostics/templates/bluescreen.phtml
+++ b/Nette/Diagnostics/templates/bluescreen.phtml
@@ -109,7 +109,7 @@ $counter = 0;
 
 
 
-			<?php $stack = is_callable(array($ex, 'getCustomTrace')) ? $ex->getCustomTrace() : $ex->getTrace(); $expanded = NULL ?>
+			<?php $stack = $ex->getTrace(); if (method_exists($ex, 'getCustomTrace')) { $rm = new \ReflectionMethod($ex, 'getCustomTrace'); if ($rm->isPublic() && !$rm->isStatic()) $stack = $ex->getCustomTrace(); } $expanded = NULL ?>
 			<?php if ($this->isCollapsed($ex->getFile())) {
 				foreach ($stack as $key => $row) {
 					if (isset($row['file']) && !$this->isCollapsed($row['file'])) { $expanded = $key; break; }


### PR DESCRIPTION
I don't like the fact that Nette\Diagnostics\Debugger doesn't show objects on the blue screen. The reason is that the necessary feature is <a href="https://bugs.php.net/bug.php?id=45351">not implemented in PHP</a> itself.

There is an <a href="http://blog.juzna.cz/2011/07/tuning-error-reporting-in-php/">implementation</a> by @juzna but it requires self-compiled PHP. Read his article if you are not sure what this is about.

I've found another way to do this, which would not work for all exceptions but only for those which use the trait below. We could easily implement this for all exceptions in Nette framework and it would be forward-compatible with future PHP (assuming the feature will be implemented in PHP one day).

``` php
trait TException
{

    private $trace;

    public function __construct($message = "", $code = 0, \Exception $previous = NULL)
    {
        $trace = debug_backtrace();
        array_shift($trace);
        $this->trace = $trace;
        $args = func_get_args();
        call_user_func_array(array($this, 'parent::__construct'), $args);
    }

    public function getCustomTrace()
    {
        return $this->trace;
    }

}
```
