### PR TITLE
Route: apply filter out even on non-scalar parameters.

### DIFF
--- a/Nette/Application/Routers/Route.php
+++ b/Nette/Application/Routers/Route.php
@@ -320,9 +320,7 @@ class Route extends Nette\Object implements Application\IRouter
 				}
 			}
 
-			if (!is_scalar($params[$name])) {
-
-			} elseif (isset($meta['filterTable2'][$params[$name]])) {
+			if (isset($meta['filterTable2'][$params[$name]])) {
 				$params[$name] = $meta['filterTable2'][$params[$name]];
 
 			} elseif (isset($meta['filterTable2']) && !empty($meta[self::FILTER_STRICT])) {

--- a/tests/Nette/Application.Routers/Route.filter.url.object.phpt
+++ b/tests/Nette/Application.Routers/Route.filter.url.object.phpt
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Test: Nette\Application\Routers\Route with FILTER_IN & FILTER_OUT using string <=> object conversion
+ *
+ * @author     David Grudl
+ * @package    Nette\Application\Routers
+ */
+
+use Nette\Application\Routers\Route;
+
+
+
+require __DIR__ . '/../bootstrap.php';
+
+require __DIR__ . '/Route.inc';
+
+
+$identityMap = array();
+$identityMap[1] = new Object(1);
+$identityMap[2] = new Object(2);
+
+
+$route = new Route('<parameter>', array(
+    'presenter' => 'presenter',
+    'parameter' => array(
+        Route::FILTER_IN => function($s) use ($identityMap) {
+            return isset($identityMap[$s]) ? $identityMap[$s] : NULL;
+        },
+        Route::FILTER_OUT => function($obj) {
+            return $obj instanceof Object ? $obj->getId() : NULL;
+        },
+    ),
+));
+
+
+// Match
+testRouteIn($route, '/1/', 'presenter', array(
+    'parameter' => $identityMap[1],
+    'test' => 'testvalue',
+), '/1?test=testvalue');
+
+Assert::same('http://example.com/1', testRouteOut($route, 'presenter', array(
+    'parameter' => $identityMap[1],
+)));
+
+
+// Doesn't match
+testRouteIn($route, '/3/');
+
+Assert::same(NULL, testRouteOut($route, 'presenter', array(
+    'parameter' => NULL,
+)));
+
+
+class Object
+{
+    /** @var int */
+    private $id;
+
+
+
+    public function __construct($id)
+    {
+        $this->id = $id;
+    }
+
+
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}


### PR DESCRIPTION
Makes conversion string <=> object possible on router level.

Some use cases:
- date in url, using DateTime in presenter
- database row identificator, using entity representing that row in presenter 
