### PR TITLE
Exceptions: change inheritance

### DIFF
--- a/Nette/Application/exceptions.php
+++ b/Nette/Application/exceptions.php
@@ -14,7 +14,6 @@ namespace Nette\Application;
 use Nette;
 
 
-
 /**
  * The exception that is thrown when user attempts to terminate the current presenter or application.
  * This is special "silent exception" with no error message or code.
@@ -22,7 +21,6 @@ use Nette;
 class AbortException extends \Exception
 {
 }
-
 
 
 /**
@@ -33,7 +31,6 @@ class ApplicationException extends \Exception
 }
 
 
-
 /**
  * The exception that is thrown when a presenter cannot be loaded.
  */
@@ -42,29 +39,30 @@ class InvalidPresenterException extends \Exception
 }
 
 
-
-/**
- * Bad HTTP / presenter request exception.
- */
-class BadRequestException extends \Exception
+abstract class RequestException extends \Exception
 {
 	/** @var int */
-	protected $defaultCode = 404;
-
+	protected $defaultCode;
 
 	public function __construct($message = '', $code = 0, \Exception $previous = NULL)
 	{
 		parent::__construct($message, $code < 200 || $code > 504 ? $this->defaultCode : $code, $previous);
 	}
-
 }
 
-
+/**
+ * Bad HTTP / presenter request exception.
+ */
+class BadRequestException extends RequestException
+{
+	/** @var int */
+	protected $defaultCode = 404;
+}
 
 /**
  * Forbidden request exception - access denied.
  */
-class ForbiddenRequestException extends BadRequestException
+class ForbiddenRequestException extends RequestException
 {
 	/** @var int */
 	protected $defaultCode = 403;


### PR DESCRIPTION
ForbiddenRequestException is not instance of BadRequestException

On nette.org I found example ErrorPresenter

``` php
<?php
    public function renderDefault($exception)
    {
        if ($this->isAjax()) {
            $this->getPayload()->error = TRUE;
            $this->terminate();

        } elseif ($exception instanceof BadRequestException) {
            $this->setView('404');

        } else {
            $this->setView('500');
            Debug::processException($exception);
        }
    }
?>
```

If I decide to distinguish different Exceptions, it works, but not ForbiddenRequestException.

``` php
<?php
    public function renderDefault($exception)
    {
        if ($this->isAjax()) {
            $this->getPayload()->error = TRUE;
            $this->terminate();

        } elseif ($exception instanceof BadRequestException) {
            $this->setView('404');

        } elseif ($exception instanceof ForbiddenRequestException) { /*never, because is instance of BadRequestException */
            $this->setView('403'); //logout message,upgrade membership message etc.
        } else {
            $this->setView('500');
            Debug::processException($exception);
        }
    }
?>
```
