### PR TITLE
now() method

### DIFF
--- a/Nette/common/DateTime.php
+++ b/Nette/common/DateTime.php
@@ -64,6 +64,16 @@ class DateTime extends \DateTime
 	}
 
 
+	/**
+	 * DateTime object factory of the current time and date
+	 * @return DateTime
+	 */
+	public static function now()
+	{
+		return self::from(date('m/d/Y h:i:s a', time()));
+	}
+
+
 
 	public function __toString()
 	{


### PR DESCRIPTION
now() factory of Nette\DateTime returning a DateTime coresponding to current time&date
