### PR TITLE
Session: restore error handler only once when starting fails

### DIFF
--- a/Nette/Http/Session.php
+++ b/Nette/Http/Session.php
@@ -103,7 +103,7 @@ class Session extends Nette\Object
 			}
 		});
 		session_start();
-		restore_error_handler();
+		$error || restore_error_handler();
 		$this->response->removeDuplicateCookies();
 		if ($error) {
 			@session_write_close(); // this is needed


### PR DESCRIPTION
Even if an error cause an exception, error handlers should be preserved.
