### PR TITLE
Database: SqlBuilder: Using only array_values from $args array, when we use IN in WHERE statme...

### DIFF
--- a/Nette/Database/Table/SqlBuilder.php
+++ b/Nette/Database/Table/SqlBuilder.php
@@ -202,7 +202,7 @@ class SqlBuilder extends Nette\Object
 					$replace = $match[2][0] . '(NULL)';
 				} else {
 					$replace = $match[2][0] . '(?)';
-					$this->parameters[] = $arg;
+					$this->parameters[] = array_values($arg);
 				}
 			} else {
 				if ($hasOperator) {


### PR DESCRIPTION
...nt.

This change is made because
$ids = array(1 => '12')

...->where("id", $ids);

generating wrong SQL:

...
WHERE (`id` IN (`1`='12'))
