### PR TITLE
SimpleRouter: fixed array to string conversion if presenter key contains array

### DIFF
--- a/Nette/Application/Routers/SimpleRouter.php
+++ b/Nette/Application/Routers/SimpleRouter.php
@@ -78,8 +78,8 @@ class SimpleRouter extends Nette\Object implements Application\IRouter
 		$params = $httpRequest->getQuery();
 		$params += $this->defaults;
 
-		if (!isset($params[self::PRESENTER_KEY])) {
-			throw new Nette\InvalidStateException('Missing presenter.');
+		if (!isset($params[self::PRESENTER_KEY]) || !is_string($params[self::PRESENTER_KEY])) {
+			return NULL;
 		}
 
 		$presenter = $this->module . $params[self::PRESENTER_KEY];

--- a/tests/Nette/Application.Routers/SimpleRouter.invalid.phpt
+++ b/tests/Nette/Application.Routers/SimpleRouter.invalid.phpt
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Test: Nette\Application\Routers\SimpleRouter invalid request.
+ *
+ * @author     Jan Tvrdík
+ * @package    Nette\Application\Routers
+ */
+
+use Nette\Http,
+	Nette\Application\Routers\SimpleRouter;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+
+
+test(function() {
+	$router = new SimpleRouter();
+	$url = new Http\UrlScript('http://nette.org?presenter[]=foo');
+	$httpRequest = new Http\Request($url);
+	$req = $router->match($httpRequest);
+
+	Assert::null( $req );
+});
+
+test(function() {
+	$router = new SimpleRouter();
+	$url = new Http\UrlScript('http://nette.org');
+	$httpRequest = new Http\Request($url);
+	$req = $router->match($httpRequest);
+
+	Assert::null( $req );
+});


### PR DESCRIPTION
Simple bugfix + changed behavior to return `NULL` instead of throwing exception if presenter key is missing.

Very similar bug is in Route if using mask `'foo ? presenter = <presenter>'`. I'll send a separate pull request / issue for that.
