### PR TITLE
Route: fixed returning invalid application request with presenter as array

### DIFF
--- a/Nette/Application/Routers/Route.php
+++ b/Nette/Application/Routers/Route.php
@@ -237,6 +237,8 @@ class Route extends Nette\Object implements Application\IRouter
 		// 5) BUILD Request
 		if (!isset($params[self::PRESENTER_KEY])) {
 			throw new Nette\InvalidStateException('Missing presenter in route definition.');
+		} elseif (!is_string($params[self::PRESENTER_KEY])) {
+			return NULL;
 		}
 		if (isset($this->metadata[self::MODULE_KEY])) {
 			if (!isset($params[self::MODULE_KEY])) {

--- a/tests/Nette/Application.Routers/Route.withNamedParamsInQuery.phpt
+++ b/tests/Nette/Application.Routers/Route.withNamedParamsInQuery.phpt
@@ -29,3 +29,5 @@ testRouteIn($route, '/?act=default', 'Default', array(
 	'action' => 'default',
 	'test' => 'testvalue',
 ), '/?test=testvalue');
+
+testRouteIn($route, '/?action[]=invalid&act=default', NULL);


### PR DESCRIPTION
Route must never return an invalid application request. 
