### PR TITLE
Session: Change sendCookie to be protected

### DIFF
--- a/Nette/Http/Session.php
+++ b/Nette/Http/Session.php
@@ -65,7 +65,7 @@ class Session extends Nette\Object
 	private $request;
 
 	/** @var IResponse */
-	private $response;
+	protected $response;
 
 
 	public function __construct(IRequest $request, IResponse $response)
@@ -527,7 +527,7 @@ class Session extends Nette\Object
 	 * Sends the session cookies.
 	 * @return void
 	 */
-	private function sendCookie()
+	protected function sendCookie()
 	{
 		if (!headers_sent() && ob_get_level() && ob_get_length()) {
 			trigger_error("Possible problem: you are starting session while already having some data in output buffer. This may not work if the outputted data grows. Try starting the session earlier.", E_USER_NOTICE);


### PR DESCRIPTION
I want to extend Session so that on every session ID generation I generate my own token similar to session ID. I need to save this token to cookie (using Response::setCookie) but I can't extend/overload sendCookie because it is private. And I can't use $response because it is private (however this limitation could be avoided by overloading constructor).

You might ask what is this good for. I have a PHP app and a nodejs app. I want to share session between these too. But I don't want to put PHPSESSID in a risk so I create my own token (which doesn't have httpOnly in order to share it with app on different protocol) and send it this way.
