### PR TITLE
Form setRenderer was not following convention of other setters

### DIFF
--- a/Nette/Forms/Form.php
+++ b/Nette/Forms/Form.php
@@ -516,7 +516,7 @@ class Form extends Container
 	 * Sets form renderer.
 	 * @return self
 	 */
-	public function setRenderer(IFormRenderer $renderer)
+	public function setRenderer(IFormRenderer $renderer = NULL)
 	{
 		$this->renderer = $renderer;
 		return $this;


### PR DESCRIPTION
Warning: This might just turn out to be a silly issue.

setTranslator is optional and has NULL
setRenderer is optional too and is missing default value NULL
