### PR TITLE
Nette\DI\Compiler: fixed multiple inheritance service definition

### DIFF
--- a/Nette/DI/Compiler.php
+++ b/Nette/DI/Compiler.php
@@ -164,9 +164,17 @@ class Compiler extends Nette\Object
 		$factories = isset($config['factories']) ? $config['factories'] : array();
 		$all = array_merge($services, $factories);
 
-		uasort($all, function($a, $b) {
-			return strcmp(Config\Helpers::isInheriting($a), Config\Helpers::isInheriting($b));
-		});
+		$depths = array();
+		foreach ($all as $origName => $def) {
+			if (!Helpers::isInheriting($def)) {
+				$depths[$origName] = 0;
+
+			} else {
+				$depths[$origName] = $depths[$def[Helpers::EXTENDS_KEY]] + 1;
+			}
+		}
+
+		array_multisort($depths, SORT_NUMERIC, SORT_ASC, $all);
 
 		foreach ($all as $origName => $def) {
 			$shared = array_key_exists($origName, $services);


### PR DESCRIPTION
When inheriting factories in my config.neon I'm having tough times when I'm inheriting multiple times (i.e. more then 1 level down).

Sometimes it says that the service does not exists. I think it's because of the sorting (IMHO sort just by inheritance flag is not enough).

So I've created a simple depth collector which is then used as a sorting pattern. That makes the parent services be the first processed and available for the child services later on.

Related forum topics (cze):
- http://forum.nette.org/cs/12969-poradi-definovanych-sluzeb
- http://forum.nette.org/cs/12232-opetovne-dedeni-jiz-zdedene-sluzby
