### PR TITLE
#1159: check extension method before magic @method

### DIFF
--- a/Nette/common/ObjectMixin.php
+++ b/Nette/common/ObjectMixin.php
@@ -69,6 +69,10 @@ final class ObjectMixin
 				throw new UnexpectedValueException("Property $class::$$name must be array or NULL, " . gettype($_this->$name) ." given.");
 			}
 
+		} elseif ($cb = self::getExtensionMethod($class, $name)) { // extension methods
+			array_unshift($args, $_this);
+			return Nette\Utils\Callback::invokeArgs($cb, $args);
+
 		} elseif (isset($methods[$name])) { // magic @methods
 			list($op, $rp, $type) = $methods[$name];
 			if (!$rp) {
@@ -91,10 +95,6 @@ final class ObjectMixin
 				$rp->setValue($_this, $val);
 			}
 			return $_this;
-
-		} elseif ($cb = self::getExtensionMethod($class, $name)) { // extension methods
-			array_unshift($args, $_this);
-			return Nette\Utils\Callback::invokeArgs($cb, $args);
 
 		} else {
 			throw new MemberAccessException("Call to undefined method $class::$name().");


### PR DESCRIPTION
Extension methods should be checked first because @method annotation can be used just as a hint in IDE.
