### PR TITLE
Configurator: Added realpath to wwwDir parameter

### DIFF
--- a/Nette/common/Configurator.php
+++ b/Nette/common/Configurator.php
@@ -100,7 +100,9 @@ class Configurator extends Object
 		$debugMode = static::detectDebugMode();
 		return array(
 			'appDir' => isset($trace[1]['file']) ? dirname($trace[1]['file']) : NULL,
-			'wwwDir' => isset($_SERVER['SCRIPT_FILENAME']) ? dirname($_SERVER['SCRIPT_FILENAME']) : NULL,
+			'wwwDir' => isset($_SERVER['SCRIPT_FILENAME'])
+				? dirname(realpath($_SERVER['SCRIPT_FILENAME']))
+				: NULL,
 			'debugMode' => $debugMode,
 			'productionMode' => !$debugMode,
 			'environment' => $debugMode ? 'development' : 'production',


### PR DESCRIPTION
appDir is also realpath (http://www.php.net/manual/en/language.constants.predefined.php -> **FILE**) so wwwDir should be too. I came across this when I was comparing wwwDir and SplFileInfo::getPath() when there was a symbolic link in the path.
