### PR TITLE
Http Response: enable custom status codes

### DIFF
--- a/Nette/Http/Response.php
+++ b/Nette/Http/Response.php
@@ -64,14 +64,7 @@ final class Response extends Nette\Object implements IResponse
 	{
 		$code = (int) $code;
 
-		static $allowed = array(
-			200=>1, 201=>1, 202=>1, 203=>1, 204=>1, 205=>1, 206=>1,
-			300=>1, 301=>1, 302=>1, 303=>1, 304=>1, 307=>1,
-			400=>1, 401=>1, 403=>1, 404=>1, 405=>1, 406=>1, 408=>1, 410=>1, 412=>1, 415=>1, 416=>1,
-			500=>1, 501=>1, 503=>1, 505=>1
-		);
-
-		if (!isset($allowed[$code])) {
+		if ($code < 100 || $code > 599) {
 			throw new Nette\InvalidArgumentException("Bad HTTP response '$code'.");
 
 		} elseif (headers_sent($file, $line)) {


### PR DESCRIPTION
Although I realize advantages of having list of usable response codes in standard application, I ran into problem with it. 

I can't use custom status codes such as 422 (Unprocessable Entity) or 429 (Too Many Requests) which is pretty common (especially in Restful services). Only way how to do it is to make proxy class such as https://github.com/drahak/Restful/blob/master/src/Drahak/Restful/Http/ResponseProxy.php#L46-L57 which is not good.

Since even specification says that HTTP Status codes are extensible (see below) when client understands the class (first digit in status code), my purpose is to allow all codes in interval <100; 599>

http://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html#sec6.1.1

```
HTTP status codes are extensible. HTTP applications are not required to understand the meaning of all registered status codes, though such understanding is obviously desirable. However, applications MUST understand the class of any status code, as indicated by the first digit, and treat any unrecognized response as being equivalent to the x00 status code of that class, with the exception that an unrecognized response MUST NOT be cached. For example, if an unrecognized status code of 431 is received by the client, it can safely assume that there was something wrong with its request and treat the response as if it had received a 400 status code. In such cases, user agents SHOULD present to the user the entity returned with the response, since that entity is likely to include human- readable information which will explain the unusual status.
```
