### PR TITLE
FileStorage: set permissions of files and directories

### DIFF
--- a/Nette/Caching/Storages/FileStorage.php
+++ b/Nette/Caching/Storages/FileStorage.php
@@ -63,11 +63,17 @@ class FileStorage extends Nette\Object implements Nette\Caching\IStorage
 	/** @var IJournal */
 	private $journal;
 
+	/** @var int|NULL */
+	private $fileMode;
+
+	/** @var int|NULL */
+	private $dirMode;
+
 	/** @var array */
 	private $locks;
 
 
-	public function __construct($dir, IJournal $journal = NULL)
+	public function __construct($dir, IJournal $journal = NULL, $fileMode = NULL, $dirMode = NULL)
 	{
 		$this->dir = realpath($dir);
 		if ($this->dir === FALSE) {
@@ -76,6 +82,8 @@ class FileStorage extends Nette\Object implements Nette\Caching\IStorage
 
 		$this->useDirs = (bool) static::$useDirectories;
 		$this->journal = $journal;
+		$this->fileMode = $fileMode;
+		$this->dirMode = $dirMode;
 
 		if (mt_rand() / mt_getrandmax() < static::$gcProbability) {
 			$this->clean(array());
@@ -150,6 +158,9 @@ class FileStorage extends Nette\Object implements Nette\Caching\IStorage
 		$cacheFile = $this->getCacheFile($key);
 		if ($this->useDirs && !is_dir($dir = dirname($cacheFile))) {
 			@mkdir($dir); // @ - directory may already exist
+			if ($this->dirMode !== NULL && !@chmod($dir, $this->dirMode)) {
+				throw new Nette\IOException("Unable to chmod dir '$dir'.");
+			}
 		}
 		$handle = @fopen($cacheFile, 'r+b'); // @ - file may not exist
 		if (!$handle) {
@@ -157,6 +168,9 @@ class FileStorage extends Nette\Object implements Nette\Caching\IStorage
 			if (!$handle) {
 				return;
 			}
+		}
+		if ($this->fileMode !== NULL && !@chmod($cacheFile, $this->fileMode)) {
+			throw new Nette\IOException("Unable to chmod file '$cacheFile'.");
 		}
 
 		$this->locks[$key] = $handle;
@@ -329,6 +343,9 @@ class FileStorage extends Nette\Object implements Nette\Caching\IStorage
 		$handle = @fopen($file, 'r+b'); // @ - file may not exist
 		if (!$handle) {
 			return NULL;
+		}
+		if ($this->fileMode !== NULL && !@chmod($file, $this->fileMode)) {
+			throw new Nette\IOException("Unable to chmod file '$file'.");
 		}
 
 		flock($handle, $lock);


### PR DESCRIPTION
I am still having troubles with issue #1039. It was closed because of umask() problems, but nobody mentioned chmod(). Why cannot FileStorage just get file and directory mode as optional constructor parameters and change file permissions itself?

So, for instance

``` php
$storage = new FileStorage($dir, $journal, 0664, 0775);
```

would  call chmod(..., 0664) on all created files and mkdir(..., 0775) on created dirs.

There would be no problems with thread safety as in the case of umask(), or am I wrong?
