### PR TITLE
:equal rule support for MultiSelect

### DIFF
--- a/client-side/netteForms.js
+++ b/client-side/netteForms.js
@@ -199,6 +199,12 @@ Nette.validators = {
 		for (var i = 0, len = arg.length; i < len; i++) {
 			if (val == arg[i]) {
 				return true;
+			} else if (elem.type === 'select-multiple' && Nette.isArray(val)) {
+				for (var j = 0, len2 = val.length; j < len2; j++) {
+					if (val[j] == arg[i]) {
+						return true;
+					}
+				}
 			}
 		}
 		return false;


### PR DESCRIPTION
If multiple values are selected `equal` rule always returns false.

$allowed = [1,2,3];
$values = [1]; // => TRUE
$values = [1,5]; // => FALSE

Provided code little changes behaviour from `equal` to `contains|intersects`
$allowed = [1,2,3];
$values = [1]; // => TRUE
$values = [1,5]; // => TRUE

Not sure if this is acceptable or another rule keyword should be used instead.
