### PR TITLE
SafeStream: Support for ftruncate

### DIFF
--- a/Nette/Utils/SafeStream.php
+++ b/Nette/Utils/SafeStream.php
@@ -223,6 +223,17 @@ final class SafeStream
 
 
 	/**
+	 * Truncates a file to a given length.
+	 * @param  int    The size to truncate to.
+	 * @return bool
+	 */
+	public function stream_truncate($size)
+	{
+		return ftruncate($this->tempHandle, $size);
+	}
+
+
+	/**
 	 * Returns the position of the file.
 	 * @return int
 	 */


### PR DESCRIPTION
Is there any special reason why SafeStream does not support `ftruncate()`?

It is not necessary, but it would be nice.
