### PR TITLE
Debugger bar: change error panel delimiter

### DIFF
--- a/Nette/Diagnostics/Debugger.php
+++ b/Nette/Diagnostics/Debugger.php
@@ -513,7 +513,7 @@ final class Debugger
 		}
 
 		$message = 'PHP ' . (isset(self::$errorTypes[$severity]) ? self::$errorTypes[$severity] : 'Unknown error') . ": $message";
-		$count = & self::getBar()->getPanel(__CLASS__ . ':errors')->data["$message|$file|$line"];
+		$count = & self::getBar()->getPanel(__CLASS__ . ':errors')->data["$message\xB$file\xB$line"];
 
 		if ($count++) { // repeated error
 			return NULL;

--- a/Nette/Diagnostics/templates/bar.errors.panel.phtml
+++ b/Nette/Diagnostics/templates/bar.errors.panel.phtml
@@ -16,7 +16,7 @@ use Nette;
 <div class="nette-inner">
 <table>
 <?php $i = 0 ?>
-<?php foreach ($data as $item => $count): list($message, $file, $line) = explode('|', $item) ?>
+<?php foreach ($data as $item => $count): list($message, $file, $line) = explode("\xB", $item) ?>
 <tr class="<?php echo $i++ % 2 ? 'nette-alt' : '' ?>">
 	<td class="nette-right"><?php echo $count ? "$count\xC3\x97" : '' ?></td>
 	<td><pre><?php echo htmlspecialchars($message, ENT_IGNORE), ' in ', Helpers::editorLink($file, $line) ?></pre></td>


### PR DESCRIPTION
Replaces original delimiter pipe `|` with vertical tab character `\xB`, which is presumably not used as often.

Fixes broken render of error message containing pipe a character.
### Example:

Message: `Foo\Bar: Baz->[name|code|email] is not preloaded`
**Received** output:  `PHP Notice: Foo\Bar: Baz->[name in code:email] failed`
**Expected** output: `PHP Notice: Foo\Bar: Baz->[name|code|email] failed in .../foo/Bar.php:294`
