### PR TITLE
Forms: fixed input being required when using negative rule

### DIFF
--- a/Nette/Forms/Rules.php
+++ b/Nette/Forms/Rules.php
@@ -68,7 +68,7 @@ final class Rules extends Nette\Object implements \IteratorAggregate
 	 */
 	public function isRequired()
 	{
-		return (bool) $this->required;
+		return $this->required instanceof Rule ? !$this->required->isNegative : FALSE;
 	}
 
 

--- a/tests/Nette/Forms/Rules.required.phpt
+++ b/tests/Nette/Forms/Rules.required.phpt
@@ -80,3 +80,13 @@ test(function() { // setRequired(FALSE)
 
 	Assert::same( array('Please enter a valid email address.'), $rules->validate() );
 });
+
+
+test(function () { // addRule(~Form::REQUIRED)
+	$form = new Form;
+	$input = $form->addText('text');
+
+	Assert::false( $input->isRequired() );
+	Assert::same( $input, $input->addRule(~Form::REQUIRED) );
+	Assert::false( $input->isRequired() );
+});


### PR DESCRIPTION
`$input->addRule(~Form::REQUIRED)` made the input required, causing HTML5 validation to prevent the form from being submitted.
