### PR TITLE
Fixed catchExceptions option in debug mode

### DIFF
--- a/Nette/DI/Extensions/NetteExtension.php
+++ b/Nette/DI/Extensions/NetteExtension.php
@@ -35,7 +35,7 @@ class NetteExtension extends Nette\DI\CompilerExtension
 		'application' => array(
 			'debugger' => TRUE,
 			'errorPresenter' => 'Nette:Error',
-			'catchExceptions' => NULL, // not %debugMode%
+			'catchExceptions' => '%productionMode%',
 			'mapping' => NULL
 		),
 		'routing' => array(
@@ -89,7 +89,6 @@ class NetteExtension extends Nette\DI\CompilerExtension
 	{
 		$container = $this->getContainerBuilder();
 		$config = $this->getConfig($this->defaults);
-		$config['application']['catchExceptions'] = !$container->parameters['debugMode'];
 
 		if (isset($config['xhtml'])) {
 			$config['latte']['xhtml'] = $config['xhtml'];

--- a/tests/Nette/DI/Compiler.extension.nette.phpt
+++ b/tests/Nette/DI/Compiler.extension.nette.phpt
@@ -42,6 +42,7 @@ class IpsumLoremMacros extends Nette\Latte\Macros\MacroSet
 $loader = new DI\Config\Loader;
 $config = $loader->load('files/compiler.extension.nette.neon');
 $config['parameters']['debugMode'] = FALSE;
+$config['parameters']['productionMode'] = TRUE;
 $config['parameters']['tempDir'] = '';
 
 $compiler = new DI\Compiler;


### PR DESCRIPTION
As of now this has no effect in debug mode:

``` yml
nette:
    application:
        catchExceptions: true
```

It is because the default value is applied regardless of the actual neon setting. This means setting catchExceptions to false in production mode does not work either. I'd like to test ErrorPresenter in debug mode so I want to turn it on.

There is one other thing in this commit. I'm quite aware that the `%productionMode%` parameter I used is deprecated. But I'd like you to reconsider that because it is quite useful as default value for cases like this one. Of course it can be solved by other means but those just doesn't look so cool. If you want to leave it deprecated, I'd like one of these or sth similar to work as replacement:

``` php
'catchExceptions' => 'not(%debugMode%)'
'catchExceptions' => '!%debugMode%'
```
