### PR TITLE
Fixed request parameter for error presenter to be either instance od Nette\Application\Request or NULL

### DIFF
--- a/Nette/Application/Application.php
+++ b/Nette/Application/Application.php
@@ -167,7 +167,7 @@ class Application extends Nette\Object
 			$this->httpResponse->setCode($e instanceof BadRequestException ? ($e->getCode() ?: 404) : 500);
 		}
 
-		$args = array('exception' => $e, 'request' => end($this->requests));
+		$args = array('exception' => $e, 'request' => end($this->requests) ?: NULL);
 		if ($this->presenter instanceof UI\Presenter) {
 			try {
 				$this->presenter->forward(":$this->errorPresenter:", $args);


### PR DESCRIPTION
I've tried to add typehints to ErrorPresenter:

``` php
final class ErrorPresenter extends BasePresenter
{
    public function renderDefault(\Exception $exception, \Nette\Application\Request $request = NULL)
    {
        // ...
    }
}
```

It didn't work as expected because when there was no request the end function returned FALSE and not NULL.
