### PR TITLE
Route: Global filters can reject the route.

### DIFF
--- a/Nette/Application/Routers/Route.php
+++ b/Nette/Application/Routers/Route.php
@@ -232,6 +232,9 @@ class Route extends Nette\Object implements Application\IRouter
 
 		if (isset($this->metadata[NULL][self::FILTER_IN])) {
 			$params = call_user_func($this->metadata[NULL][self::FILTER_IN], $params);
+			if ($params === NULL) {
+				return NULL;
+			}
 		}
 
 		// 5) BUILD Request
@@ -281,6 +284,9 @@ class Route extends Nette\Object implements Application\IRouter
 
 		if (isset($metadata[NULL][self::FILTER_OUT])) {
 			$params = call_user_func($metadata[NULL][self::FILTER_OUT], $params);
+			if ($params === NULL) {
+				return NULL;
+			}
 		}
 
 		if (isset($metadata[self::MODULE_KEY])) { // try split into module and [submodule:]presenter parts

--- a/tests/Nette/Application.Routers/Route.filter.global.phpt
+++ b/tests/Nette/Application.Routers/Route.filter.global.phpt
@@ -18,11 +18,17 @@ require __DIR__ . '/Route.inc';
 $route = new Route('<presenter>', array(
 	NULL => array(
 		Route::FILTER_IN => function(array $arr) {
+			if (substr($arr['presenter'], 0, 3) !== 'Abc') {
+				return NULL;
+			}
 			$arr['presenter'] .= '.in';
 			$arr['param'] .= '.in';
 			return $arr;
 		},
 		Route::FILTER_OUT => function(array $arr) {
+			if (substr($arr['presenter'], 0, 3) !== 'Abc') {
+				return NULL;
+			}
 			$arr['presenter'] .= '.out';
 			$arr['param'] .= '.out';
 			return $arr;
@@ -34,3 +40,7 @@ testRouteIn($route, '/abc?param=1', 'Abc.in', array(
 	'param' => '1.in',
 	'test' => 'testvalue',
 ), '/abc.in.out?param=1.in.out&test=testvalue');
+
+testRouteIn($route, '/cde?param=1');
+
+\Tester\Assert::null(testRouteOut($route, 'Cde'));


### PR DESCRIPTION
Adds ability to reject the whole route in global filters.

Motivation: Probably the most common use of global filters is for URL localization. But there is a problem with localizing special routes (e.g. for top-level pages). You cannot simply replace

``` php
$route = new Route(
  '<action default|about|faq>',
  array(
    'presenter' => 'Whatever',
    'action' => 'default',
  )
);
```

by this

``` php
$route = new Route(
  '[<lang [a-z]{2}>/]<action default|about|faq>',
  array(
    'presenter' => 'Whatever',
    'action' => 'default',
    NULL => array(Route::FILTER_IN => 'filterIn', Route::FILTER_OUT => 'filterOut'),
  )
);
```

The translation (by global filter) is the last thing that happens in match and the first thing that happens in constructUrl, so the canonical English names are not available when matching against regexp.

This PR overcomes the problem by allowing to reject the route in the global filter.
