### PR TITLE
Phpwriter: PHPDoc & optional MacroTokens argument for formatArray method

### DIFF
--- a/Nette/Latte/PhpWriter.php
+++ b/Nette/Latte/PhpWriter.php
@@ -135,9 +135,9 @@ class PhpWriter extends Nette\Object
 	 * Formats macro arguments to PHP array. (It advances tokenizer to the end as a side effect.)
 	 * @return string
 	 */
-	public function formatArray()
+	public function formatArray(MacroTokens $tokens = NULL)
 	{
-		$tokens = $this->preprocess();
+		$tokens = $this->preprocess($tokens);
 		$tokens = $this->expandFilter($tokens);
 		$tokens = $this->quoteFilter($tokens);
 		return $tokens->joinAll();


### PR DESCRIPTION
Fixing several errors in PHPDoc blocks of PhpWriter and adding optional argument for formatArray method (let's make it consistent with other formatting methods).
