### PR TITLE
Fixed wrong exception in ObjectMixin

### DIFF
--- a/Nette/common/ObjectMixin.php
+++ b/Nette/common/ObjectMixin.php
@@ -69,7 +69,7 @@ final class ObjectMixin
 				throw new UnexpectedValueException("Property $class::$$name must be array or NULL, " . gettype($_this->$name) ." given.");
 			}
 
-		} elseif (isset($methods[$name])) { // magic @methods
+		} elseif (isset($methods[$name]) && $methods[$name] !== 0) { // magic @methods
 			list($op, $rp, $type) = $methods[$name];
 			if (!$rp) {
 				throw new MemberAccessException("Magic method $class::$name() has not corresponding property $$op.");
@@ -97,6 +97,9 @@ final class ObjectMixin
 			return Nette\Utils\Callback::invokeArgs($cb, $args);
 
 		} else {
+			if (method_exists($class, $name)) { // called parent::$name()
+				$class = 'parent';
+			}
 			throw new MemberAccessException("Call to undefined method $class::$name().");
 		}
 	}

--- a/tests/Nette/common/Object.magicMethod.errors.phpt
+++ b/tests/Nette/common/Object.magicMethod.errors.phpt
@@ -20,6 +20,11 @@ require __DIR__ . '/../bootstrap.php';
 class TestClass extends Nette\Object
 {
 	protected $items = array();
+	
+	public function abc()
+	{
+		parent::abc();
+	}
 }
 
 // Undeclared method access
@@ -27,6 +32,11 @@ Assert::exception(function() {
 	$obj = new TestClass;
 	$obj->setAbc();
 }, 'Nette\MemberAccessException', 'Call to undefined method TestClass::setAbc().');
+
+Assert::exception(function() {
+	$obj = new TestClass;
+	$obj->abc();
+}, 'Nette\MemberAccessException', PHP_VERSION_ID != 50303 ? 'Call to undefined method parent::abc().' : 'Call to undefined static method TestClass::abc().'); // PHP bug #52713 (exclusive to PHP 5.3.3)
 
 
 // Wrong parameters count


### PR DESCRIPTION
Previously I got a very confusing exception:

```
Nette\MemberAccessException
Magic method Class::method() has not corresponding property $.
```

See the test for use-case.
