### PR TITLE
netteForms.js: Make it easier to override retrieving of element value and rule arguments expansion

### DIFF
--- a/client-side/netteForms.js
+++ b/client-side/netteForms.js
@@ -169,6 +169,17 @@ Nette.addError = function(elem, message) {
 
 
 /**
+ * Expand rule argument.
+ */
+Nette.expandRuleArgument = function(elem, arg) {
+	if (arg && arg.control) {
+		arg = Nette.getEffectiveValue(elem.form.elements[arg.control]);
+	}
+	return arg;
+};
+
+
+/**
  * Validates single rule.
  */
 Nette.validateRule = function(elem, op, arg) {
@@ -182,9 +193,7 @@ Nette.validateRule = function(elem, op, arg) {
 
 	var arr = Nette.isArray(arg) ? arg.slice(0) : [arg];
 	for (var i = 0, len = arr.length; i < len; i++) {
-		if (arr[i] && arr[i].control) {
-			arr[i] = Nette.getEffectiveValue(elem.form.elements[arr[i].control]);
-		}
+		arr[i] = Nette.expandRuleArgument(elem, arr[i]);
 	}
 	return Nette.validators[op] ? Nette.validators[op](elem, Nette.isArray(arg) ? arr : arr[0], val) : null;
 };


### PR DESCRIPTION
1) Method getEffectiveValue is used for retrieving a value of an element for the purpose of its validation, the error reporting still uses getValue method, so the user is presented with the actual value of the element (in the error message).
The default implementation filters out "empty value".
Here comes the fun part - imagine you have a datepicker input and you want to add RANGE rule to limit the allowed dates... that's pretty easy now:

``` javascript
Nette.getEffectiveValue = function(elem) {
  if (window.jQuery && jQuery(elem).hasClass('hasDatepicker')) {
    var val = jQuery(elem).datepicker('getDate');
    return val ? val.getTime() : null;
  } else {
    ...
  }
}
```

Effective value is now an integer which can be used for comparisons in RANGE validation.

2) Method expandRuleArgument is used for expanding the rule arguments for the purpose of validation. The default implementation replaces references to other controls with their current effective value.
The motivation here is that you may want to use objects as arguments for your validation rules, e.g. DateTime instance, which can be directly compared on server-side, but on client-side you need to parse it before passing it to validator.
