### PR TITLE
Marked Session::clean() as internal

### DIFF
--- a/Nette/Http/Session.php
+++ b/Nette/Http/Session.php
@@ -331,7 +331,8 @@ class Session extends Nette\Object
 
 
 	/**
-	 * Cleans and minimizes meta structures.
+	 * Cleans and minimizes meta structures. This method is called automatically on shutdown, do not call it directly.
+	 * @internal
 	 * @return void
 	 */
 	public function clean()


### PR DESCRIPTION
Direct call of this method can cause significant errors, see http://forum.nette.org/cs/12241-session-zustava-aktivni-i-po-zavreni-prohlizece-i-kdyz-by-nemela (czech only). It's called automatically on shutdown so there is no need to call it elsewhere.
