### PR TITLE
RadioList: remove unneeded attribute setter.

### DIFF
--- a/Nette/Forms/Controls/RadioList.php
+++ b/Nette/Forms/Controls/RadioList.php
@@ -195,7 +195,6 @@ class RadioList extends BaseControl
 
 		if ($key !== NULL) {
 			return $input->addAttributes(array(
-				'type' => 'radio',
 				'id' => $this->getHtmlId() . "-$key",
 				'checked' => isset($selected[$key]),
 				'value' => $key,


### PR DESCRIPTION
type=radio is already set in the constructor
