### PR TITLE
Možnost escapovat tečku v cestě v config.neon

### DIFF
--- a/Nette/DI/Helpers.php
+++ b/Nette/DI/Helpers.php
@@ -63,7 +63,9 @@ final class Helpers
 				throw new Nette\InvalidArgumentException('Circular reference detected for variables: ' . implode(', ', array_keys($recursive)) . '.');
 
 			} else {
-				$val = Nette\Utils\Arrays::get($params, explode('.', $part));
+				$partSplit = preg_split('#(?<!\.)\.(?!\.)#i', $part);
+				array_walk($partSplit, function(&$segment) { $segment = preg_replace('#\.{2}#i', '.', $segment); });
+				$val = Nette\Utils\Arrays::get($params, $partSplit);
 				if ($recursive) {
 					$val = self::expand($val, $params, (is_array($recursive) ? $recursive : array()) + array($part => 1));
 				}


### PR DESCRIPTION
Možnost v config.neon v %odkazu% escapovat tečku druhou tečkou, pokud jsou po cestě klíče obsahující tečku.

```
common:
    parameters:
        parametr.prvni:
            klic1: 'hodnota'
            klic2: 12
        parametr.druhy:
            klic1: %parameters.parametr..prvni.klic1%
            klic2: %parameters.parametr..prvni.klic2%
...
```
