### PR TITLE
Showing debug panels in front of debugger message

### DIFF
--- a/Nette/Diagnostics/templates/bar.js
+++ b/Nette/Diagnostics/templates/bar.js
@@ -18,7 +18,7 @@
 	Panel.FLOAT = 'nette-mode-float';
 	Panel.WINDOW = 'nette-mode-window';
 	Panel.FOCUSED = 'nette-focused';
-	Panel.zIndex = 20000;
+	Panel.zIndex = 24000;
 
 	Panel.prototype.init = function() {
 		var _this = this;


### PR DESCRIPTION
Debug panels from debug bar were showing behind a debugger message (but debug bar was visible)
