### PR TITLE
Arrays::flatten - possibility to preserve keys

### DIFF
--- a/Nette/Utils/Arrays.php
+++ b/Nette/Utils/Arrays.php
@@ -156,10 +156,13 @@ final class Arrays
 	 * Returns flattened array.
 	 * @return array
 	 */
-	public static function flatten(array $arr)
+	public static function flatten(array $arr, $preserveKeys = FALSE)
 	{
 		$res = array();
-		array_walk_recursive($arr, function($a) use (& $res) { $res[] = $a; });
+		$cb = $preserveKeys
+			? function($v, $k) use (& $res) { $res[$k] = $v; }
+			: function($v) use (& $res) { $res[] = $v; };
+		array_walk_recursive($arr, $cb);
 		return $res;
 	}
 

--- a/tests/Nette/Utils/Arrays.flatten().phpt
+++ b/tests/Nette/Utils/Arrays.flatten().phpt
@@ -19,10 +19,27 @@ $res = Arrays::flatten(array(
 	'e',
 ));
 
-Assert::same( array(
+Assert::same(array(
 	0 => 'a',
 	1 => 'b',
 	2 => 'c',
 	3 => 'd',
 	4 => 'e',
+), $res);
+
+$res = Arrays::flatten(array(
+	5 => 'a',
+	10 => array(
+		'z' => 'b',
+		1 => 'c',
+	),
+	'y' => 'd',
+	'z' => 'e',
+), TRUE);
+
+Assert::same(array(
+	5 => 'a',
+	'z' => 'e',
+	1 => 'c',
+	'y' => 'd',
 ), $res);


### PR DESCRIPTION
Simple & handful possibility to preserve keys while flattening array.
In case of duplicate keys, last one wins, which is same behavoir with native php functions, e.g. array_flip or array_merge.

Change is fully backward compatible as the default value is `FALSE` <del>unless one was overriding the method in userland</del> (could not -- it's final). :)
