### PR TITLE
Fixed response code

### DIFF
--- a/Nette/Http/Response.php
+++ b/Nette/Http/Response.php
@@ -47,7 +47,7 @@ final class Response extends Nette\Object implements IResponse
 	public function __construct()
 	{
 		if (PHP_VERSION_ID >= 50400) {
-			$this->code = http_response_code();
+			$this->code = http_response_code() ?: self::S200_OK;
 			header_register_callback($this->removeDuplicateCookies);
 		}
 	}


### PR DESCRIPTION
For some reason the function http_response_code returns FALSE in some cases (even though the PHP documentation says otherwise, so yeah it's PHP bug). I've experienced it when I was writing some functional tests with Codeception but I can't reproduce it when testing just Nette. Therefore I didn't write a test.
