### PR TITLE
TokenIterator: allow calling the scan method from inheritors

### DIFF
--- a/Nette/Utils/TokenIterator.php
+++ b/Nette/Utils/TokenIterator.php
@@ -190,7 +190,7 @@ class TokenIterator extends Nette\Object
 	 * Looks for (first) (not) wanted tokens.
 	 * @return mixed
 	 */
-	private function scan($wanted, $onlyFirst, $advance, $strings = FALSE, $until = FALSE, $prev = FALSE)
+	final protected function scan($wanted, $onlyFirst, $advance, $strings = FALSE, $until = FALSE, $prev = FALSE)
 	{
 		$res = $onlyFirst ? NULL : ($strings ? '' : array());
 		$pos = $this->position + ($prev ? -1 : 1);


### PR DESCRIPTION
I need advanced ways of scanning the tokens (for example "lookbehind" farther than -1).
