### PR TITLE
Configurator: require DIC only once

### DIFF
--- a/Nette/common/Configurator.php
+++ b/Nette/common/Configurator.php
@@ -164,7 +164,7 @@ class Configurator extends Object
 			$cache->save($cacheKey, $code, array($cache::FILES => $dependencies));
 			$cached = $cache->load($cacheKey);
 		}
-		require $cached['file'];
+		require_once $cached['file'];
 
 		$container = new $this->parameters['container']['class'];
 		$container->initialize();


### PR DESCRIPTION
When I use Configurator in tests to build DIC to run integration test. When used in combination with Nette/Tester and data providers, the setup method builds the container repeatedly, and not even hacking the container doesn't work

``` php
$config->addParameters(array('container' => array('class' => 'SystemContainer_'  . md5(microtime()) )))
```

because there are other generated classes (generated interface factories) which have the exactly same class.
