### PR TITLE
Allow having multiple compiled DI containers

### DIFF
--- a/Nette/DI/Compiler.php
+++ b/Nette/DI/Compiler.php
@@ -139,10 +139,8 @@ class Compiler extends Nette\Object
 			$this->container->addDependency(Nette\Reflection\ClassType::from($extension)->getFileName());
 		}
 
-		$classes = $this->container->generateClasses();
-		$classes[0]->setName($className)
-			->setExtends($parentName)
-			->addMethod('initialize');
+		$classes = $this->container->generateClasses($className, $parentName);
+		$classes[0]->addMethod('initialize');
 
 		foreach ($this->extensions as $extension) {
 			$extension->afterCompile($classes[0]);


### PR DESCRIPTION
It is possible to have several containers compiled and used within one application under different class names.
However, auto generated factory classes are not namespaced and thus cause class-redeclaration fatal error.

This commit prefixes all factory classes with container name, making them unique and thus allowing to have several DI containers together.
