### PR TITLE
Diagnostics: debug bar should be always in LTR direction

### DIFF
--- a/Nette/Diagnostics/templates/bar.css
+++ b/Nette/Diagnostics/templates/bar.css
@@ -8,6 +8,7 @@
 /* common styles */
 #nette-debug {
 	display: none;
+	direction: ltr;
 }
 
 body#nette-debug {


### PR DESCRIPTION
When developing in RTL mode (Arabic etc.), debug bar is screwed, example from sandbox:
![screenshot from 2013-12-02 10 27 44](https://f.cloud.github.com/assets/144181/1653402/09114d38-5b34-11e3-9380-b7c7e2542b74.png)

This change preserves LTR behavior even in RTL mode.
