### PR TITLE
NetteExtension.php: method setupApplication() at line # 208 is unnecessary semicolon

### DIFF
--- a/Nette/DI/Extensions/NetteExtension.php
+++ b/Nette/DI/Extensions/NetteExtension.php
@@ -205,7 +205,7 @@ class NetteExtension extends Nette\DI\CompilerExtension
 			->setClass('Nette\Application\Application')
 			->addSetup('$catchExceptions', array($config['catchExceptions']))
 			->addSetup('$errorPresenter', array($config['errorPresenter']))
-			->addSetup('!headers_sent() && header(?);', array('X-Powered-By: Nette Framework'));
+			->addSetup('!headers_sent() && header(?)', array('X-Powered-By: Nette Framework'));
 
 		if ($config['debugger']) {
 			$application->addSetup('Nette\Application\Diagnostics\RoutingPanel::initializePanel');


### PR DESCRIPTION
After generating the configuration at the end of the line unnecessarily 2x semicolon.

```
/**
 * @return Nette\Application\Application
 */
public function createServiceApplication()
{
    ...
    !headers_sent() && header('X-Powered-By: Nette Framework');;
    ...

}
```
