### PR TITLE
FormMacros: Use braces to delimit conditional statements.

### DIFF
--- a/Nette/Latte/Macros/FormMacros.php
+++ b/Nette/Latte/Macros/FormMacros.php
@@ -95,7 +95,7 @@ class FormMacros extends MacroSet
 		$name = array_shift($words);
 		return $writer->write(
 			($name[0] === '$' ? '$_input = is_object(%0.word) ? %0.word : $_form[%0.word]; if ($_label = $_input' : 'if ($_label = $_form[%0.word]')
-			. '->%1.raw) echo $_label->addAttributes(%node.array)',
+			. '->%1.raw) {echo $_label->addAttributes(%node.array);}',
 			$name,
 			$words ? ('getLabelPart(' . implode(', ', array_map(array($writer, 'formatWord'), $words)) . ')') : 'getLabel()'
 		);
@@ -109,7 +109,7 @@ class FormMacros extends MacroSet
 	{
 		if ($node->content != NULL) {
 			$node->openingCode = substr_replace($node->openingCode, '->startTag()', strrpos($node->openingCode, ')') + 1, 0);
-			return $writer->write('if ($_label) echo $_label->endTag()');
+			return $writer->write('if ($_label) {echo $_label->endTag();}');
 		}
 	}
 

--- a/tests/Nette/Latte/expected/macros.forms.formContainer.phtml
+++ b/tests/Nette/Latte/expected/macros.forms.formContainer.phtml
@@ -6,16 +6,16 @@
 Nette\Latte\Macros\FormMacros::renderFormBegin($form = $_form = $_control["myForm"], array()) ?>
 <table>
 	<tr>
-		<th><?php if ($_label = $_form["input1"]->getLabel()) echo $_label->addAttributes(array())  ?></th>
+		<th><?php if ($_label = $_form["input1"]->getLabel()) {echo $_label->addAttributes(array());} ?></th>
 		<td><?php echo $_form["input1"]->getControl()->addAttributes(array()) ?></td>
 	</tr>
 <?php $_formStack[] = $_form; $formContainer = $_form = $_form["cont1"] ?>
 	<tr>
-		<th><?php if ($_label = $_form["input2"]->getLabel()) echo $_label->addAttributes(array())  ?></th>
+		<th><?php if ($_label = $_form["input2"]->getLabel()) {echo $_label->addAttributes(array());} ?></th>
 		<td><?php echo $_form["input2"]->getControl()->addAttributes(array()) ?></td>
 	</tr>
 	<tr>
-		<th><?php if ($_label = $_form["input3"]->getLabel()) echo $_label->addAttributes(array())  ?></th>
+		<th><?php if ($_label = $_form["input3"]->getLabel()) {echo $_label->addAttributes(array());} ?></th>
 		<td><?php echo $_form["input3"]->getControl()->addAttributes(array()) ?></td>
 	</tr>
 	<tr>
@@ -29,12 +29,12 @@ Nette\Latte\Macros\FormMacros::renderFormBegin($form = $_form = $_control["myFor
 		</td>
 	</tr>
 	<tr>
-		<th><?php if ($_label = $_form["input7"]->getLabel()) echo $_label->addAttributes(array())  ?></th>
+		<th><?php if ($_label = $_form["input7"]->getLabel()) {echo $_label->addAttributes(array());} ?></th>
 		<td><?php echo $_form["input7"]->getControl()->addAttributes(array()) ?></td>
 	</tr>
 <?php $_form = array_pop($_formStack) ?>
 	<tr>
-		<th><?php if ($_label = $_form["input8"]->getLabel()) echo $_label->addAttributes(array())  ?></th>
+		<th><?php if ($_label = $_form["input8"]->getLabel()) {echo $_label->addAttributes(array());} ?></th>
 		<td><?php echo $_form["input8"]->getControl()->addAttributes(array()) ?></td>
 	</tr>
 </table>

--- a/tests/Nette/Latte/expected/macros.forms.phtml
+++ b/tests/Nette/Latte/expected/macros.forms.phtml
@@ -1,19 +1,19 @@
 <?php
 %A%
 Nette\Latte\Macros\FormMacros::renderFormBegin($form = $_form = $_control["myForm"], array('id' => 'myForm', 'class'=>"ajax")) ;$iterations = 0; foreach (array('id', 'username', 'select', 'area', 'send') as $name): ?>
-		<?php $_input = is_object($name) ? $name : $_form[$name]; if ($_label = $_input->getLabel()) echo $_label->addAttributes(array())  ?>
+		<?php $_input = is_object($name) ? $name : $_form[$name]; if ($_label = $_input->getLabel()) {echo $_label->addAttributes(array());} ?>
 
 <?php $_input = is_object($name) ? $name : $_form[$name]; echo $_input->getControl()->addAttributes(array('title' => 'Hello', 'size' => 10)) ?>
 
 		<br>
 
-		<?php $_input = is_object($form[$name]) ? $form[$name] : $_form[$form[$name]]; if ($_label = $_input->getLabel()) echo $_label->addAttributes(array('title' => 'hello'))->startTag() ?>
+		<?php $_input = is_object($form[$name]) ? $form[$name] : $_form[$form[$name]]; if ($_label = $_input->getLabel()) {echo $_label->addAttributes(array('title' => 'hello'))->startTag();} ?>
  <?php $_input = is_object($form[$name]) ? $form[$name] : $_form[$form[$name]]; echo $_input->getControl()->addAttributes(array('title' => 'Hello', 'size' => 10)) ?>
- <?php if ($_label) echo $_label->endTag() ?>
+ <?php if ($_label) {echo $_label->endTag();} ?>
 
 <?php $iterations++; endforeach ?>
 
-	<?php $_input = is_object($form['username']) ? $form['username'] : $_form[$form['username']]; if ($_label = $_input->getLabel()) echo $_label->addAttributes(array())  ?>
+	<?php $_input = is_object($form['username']) ? $form['username'] : $_form[$form['username']]; if ($_label = $_input->getLabel()) {echo $_label->addAttributes(array());} ?>
 
 
 	<LABEL title=hello<?php $_input = $_form["username"]; echo $_input->getLabel()->addAttributes(array (
@@ -38,8 +38,8 @@ Nette\Latte\Macros\FormMacros::renderFormBegin($form = $_form = $_control["myFor
 
 
 <?php $iterations = 0; foreach ($form['sex']->items as $key => $label): ?>
-	<?php if ($_label = $_form["sex"]->getLabelPart($key)) echo $_label->addAttributes(array())->startTag() ?>
- <?php echo $_form["sex"]->getControlPart($key)->addAttributes(array()) ?> <?php echo Nette\Templating\Helpers::escapeHtml($label, ENT_NOQUOTES) ;if ($_label) echo $_label->endTag() ?>
+	<?php if ($_label = $_form["sex"]->getLabelPart($key)) {echo $_label->addAttributes(array())->startTag();} ?>
+ <?php echo $_form["sex"]->getControlPart($key)->addAttributes(array()) ?> <?php echo Nette\Templating\Helpers::escapeHtml($label, ENT_NOQUOTES) ;if ($_label) {echo $_label->endTag();} ?>
 
 	<label title=hello<?php $_input = $_form["sex"]; echo $_input->getLabelPart($key)->addAttributes(array (
   'title' => NULL,
@@ -47,8 +47,8 @@ Nette\Latte\Macros\FormMacros::renderFormBegin($form = $_form = $_control["myFor
 <?php $iterations++; endforeach ?>
 
 
-<?php if ($_label = $_form["checkbox"]->getLabelPart("")) echo $_label->addAttributes(array())->startTag() ?>
- <?php echo $_form["checkbox"]->getControlPart("")->addAttributes(array()) ?> Label<?php if ($_label) echo $_label->endTag() ?>
+<?php if ($_label = $_form["checkbox"]->getLabelPart("")) {echo $_label->addAttributes(array())->startTag();} ?>
+ <?php echo $_form["checkbox"]->getControlPart("")->addAttributes(array()) ?> Label<?php if ($_label) {echo $_label->endTag();} ?>
 
 <label title=hello<?php $_input = $_form["checkbox"]; echo $_input->getLabelPart("")->addAttributes(array (
   'title' => NULL,
@@ -56,9 +56,9 @@ Nette\Latte\Macros\FormMacros::renderFormBegin($form = $_form = $_control["myFor
 
 
 <?php $iterations = 0; foreach ($form['checklist']->items as $key => $label): ?>
-	<?php if ($_label = $_form["checklist"]->getLabelPart($key)) echo $_label->addAttributes(array())->startTag() ?>
+	<?php if ($_label = $_form["checklist"]->getLabelPart($key)) {echo $_label->addAttributes(array())->startTag();} ?>
  <?php echo $_form["checklist"]->getControlPart($key)->addAttributes(array()) ?>
- <?php echo Nette\Templating\Helpers::escapeHtml($label, ENT_NOQUOTES) ;if ($_label) echo $_label->endTag() ?>
+ <?php echo Nette\Templating\Helpers::escapeHtml($label, ENT_NOQUOTES) ;if ($_label) {echo $_label->endTag();} ?>
 
 	<label<?php $_input = $_form["checklist"]; echo $_input->getLabelPart($key)->attributes() ?>
 > <input title=hello<?php $_input = $_form["checklist"]; echo $_input->getControlPart($key)->addAttributes(array (


### PR DESCRIPTION
Without the braces Latte produces invalid code for one-liners like `{if $condition}{input a}{else}{input b}{/if}`.
