### PR TITLE
RFC: Native support for HTML5 inputs in forms

### DIFF
--- a/Nette/Forms/Container.php
+++ b/Nette/Forms/Container.php
@@ -347,15 +347,9 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 	 * @param  string  error message for range validation rule
 	 * @return Nette\Forms\Controls\TextInput
 	 */
-	public function addRange($name, $label = NULL, $range = NULL, $numberErrorMessage = NULL, $rangeErrorMessage = NULL)
+	public function addRange($name, $label = NULL, $range = array(0, 100), $numberErrorMessage = NULL, $rangeErrorMessage = NULL)
 	{
-		$control = new Controls\TextInput($label);
-		$rules = $control->addCondition(Form::FILLED);
-		$rules->addRule(Form::NUMERIC, $numberErrorMessage);
-		if ($range !== NULL) {
-			$rules->addRule(Form::RANGE, $rangeErrorMessage, $range);
-		}
-		return $this[$name] = $control->setType('range');
+		return $this[$name] = new Controls\RangeControl($label, $range, $numberErrorMessage, $rangeErrorMessage);
 	}
 
 

--- a/Nette/Forms/Controls/RangeControl.php
+++ b/Nette/Forms/Controls/RangeControl.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (http://nette.org)
+ * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
+ */
+
+namespace Nette\Forms\Controls;
+
+use Nette;
+
+
+/**
+ * @author Petr Morávek <petr@pada.cz>
+ */
+class RangeControl extends TextInput
+{
+
+	/**
+	 * @param  string  label
+	 * @param  array  allowed number range
+	 * @param  string  error message for numeric validation rule
+	 * @param  string  error message for range validation rule
+	 */
+	public function __construct($label = NULL, array $range = array(0, 100), $numberErrorMessage = NULL, $rangeErrorMessage = NULL)
+	{
+		parent::__construct($label);
+		$this->setType('range');
+		$this->setRequired();
+		$this->addRule(Nette\Forms\Form::NUMERIC, $numberErrorMessage);
+		$this->addRule(Nette\Forms\Form::RANGE, $rangeErrorMessage, $range);
+		//TODO filter for rounding the value to match the step attribute
+	}
+
+	/**
+	 * @param string
+	 * @return void
+	 * @throws Nette\NotSupportedException range control must be always filled
+	 */
+	public function setEmptyValue($value)
+	{
+		throw new Nette\NotSupportedException("Range control must be always filled.");
+	}
+
+}


### PR DESCRIPTION
I would like to see at least partial support for new HTML5 input types in forms. Types like search, tel, url, email are no brainer - they are basically text inputs, both modern and old browsers display them as such. This PR automagically adds validation to url and email types.
I'm not really sure about number and range types.
