### PR TITLE
Latte: apply modifier safeUrl automatically to attribute href

### DIFF
--- a/Nette/Latte/Compiler.php
+++ b/Nette/Latte/Compiler.php
@@ -64,6 +64,7 @@ class Compiler extends Nette\Object
 		CONTENT_XML = 'xml',
 		CONTENT_JS = 'js',
 		CONTENT_CSS = 'css',
+		CONTENT_URL = 'url',
 		CONTENT_ICAL = 'ical',
 		CONTENT_TEXT = 'text';
 
@@ -343,6 +344,8 @@ class Compiler extends Nette\Object
 				$context = self::CONTENT_JS;
 			} elseif ($token->name === 'style') {
 				$context = self::CONTENT_CSS;
+			} elseif (in_array($token->name, array('href', 'src', 'action', 'formaction'))) {
+				$context = self::CONTENT_URL;
 			} else {
 				$context = NULL;
 			}
@@ -529,8 +532,15 @@ class Compiler extends Nette\Object
 			throw new CompileException("Unknown macro {{$name}}" . ($cdata ? " (in JavaScript or CSS, try to put a space after bracket.)" : ''));
 		}
 
-		$modifiers = preg_replace('#\|noescape\s?(?=\||\z)#i', '', $modifiers, -1, $noescape);
-		if (!$noescape && strpbrk($name, '=~%^&_')) {
+		if ($this->context[1] === self::CONTENT_URL) {
+			$modifiers = preg_replace('#\|nosafeurl\s?(?=\||\z)#i', '', $modifiers, -1, $found);
+			if (!$found) {
+				$modifiers .= '|safeurl';
+			}
+		}
+
+		$modifiers = preg_replace('#\|noescape\s?(?=\||\z)#i', '', $modifiers, -1, $found);
+		if (!$found && strpbrk($name, '=~%^&_')) {
 			$modifiers .= '|escape';
 		}
 

--- a/tests/Nette/Latte/Safe.url.phpt
+++ b/tests/Nette/Latte/Safe.url.phpt
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Test: Nette\Latte\Engine and auto-safe URL.
+ *
+ * @author     David Grudl
+ * @package    Nette\Latte
+ */
+
+use Nette\Latte,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$template = new Nette\Templating\Template;
+$template->registerFilter(new Latte\Engine);
+$template->registerHelperLoader('Nette\Templating\Helpers::loader');
+$template->url1 = 'javascript:alert(1)';
+$template->url2 = ' javascript:alert(1)';
+$template->url3 = 'data:text/html;base64,PHN2Zy9vbmxvYWQ9YWxlcnQoMik+';
+$template->url4 = 'ok';
+$template->url5 = '';
+
+$template->setSource('
+<a href={$url1} src="{$url1}" action={$url1} formaction={$url1} title={$url1}></a>
+<a href={$url1|nosafeurl}></a>
+<a href="http://nette.org?val={$url4}"></a>
+<a href={$url2}></a>
+<a href={$url3}></a>
+<a href={$url4}>ok</a>
+<a href={$url5}></a>
+');
+
+Assert::match('
+<a href="" src="" action="" formaction="" title="javascript:alert(1)"></a>
+<a href="javascript:alert(1)"></a>
+<a href="http://nette.org?val=ok"></a>
+<a href=""></a>
+<a href=""></a>
+<a href="ok">ok</a>
+<a href=""></a>
+', (string) $template);


### PR DESCRIPTION
Yes, this is not about escaping, this is sanitization. In fact, escapeXML() provides some kind of sanitization too. Pros and cons?
