### PR TITLE
NetteExtension: add all mailer options to defaults

### DIFF
--- a/Nette/DI/Extensions/NetteExtension.php
+++ b/Nette/DI/Extensions/NetteExtension.php
@@ -51,6 +51,12 @@ class NetteExtension extends Nette\DI\CompilerExtension
 		),
 		'mailer' => array(
 			'smtp' => FALSE,
+			'host' => NULL,
+			'port' => NULL,
+			'username' => NULL,
+			'password' => NULL,
+			'secure' => NULL,
+			'timeout' => NULL,
 		),
 		'database' => array(), // of [name => dsn, user, password, debugger, explain, autowired, reflection]
 		'forms' => array(


### PR DESCRIPTION
Commit https://github.com/nette/nette/commit/2615fbab555bc1dea703a00e453b380b7cd0275f[2615fba] introduced bug where NetteExtension throws `Nette\InvalidStateException - Unknown option nette.mailer.host, nette.mailer.username, nette.mailer.password, nette.mailer.secure.` when defining any other option than `smtp` which was already defined in extension. Other sections can be afflicted too.
