### PR TITLE
Enable running tests under HHVM on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ php:
     - 5.3.3
     - 5.4
     - 5.5
+    - hhvm
+
+matrix:
+    allow_failures:
+        - php: hhvm
 
 script: VERBOSE=true ./tests/run-tests.sh -s tests/
 


### PR DESCRIPTION
Added HHVM ([HipHop Virtual Machine](https://github.com/facebook/hhvm/)) as a PHP environment to test, failures allowed.

I will soon try to work on enabling Nette to run under HHVM as well.
There are currently some regressions, due some incompatibilities or missing features (HHVM parity with Zend is not 100%).
