### PR TITLE
Fix: NetteExtension does not add BlueScreen panels (debugMode = false)

### DIFF
--- a/Nette/DI/Extensions/NetteExtension.php
+++ b/Nette/DI/Extensions/NetteExtension.php
@@ -389,13 +389,13 @@ class NetteExtension extends Nette\DI\CompilerExtension
 					Nette\DI\Compiler::filterArguments(array(is_string($item) ? new Nette\DI\Statement($item) : $item))
 				));
 			}
+		}
 
-			foreach ((array) $config['debugger']['blueScreen'] as $item) {
-				$initialize->addBody($container->formatPhp(
-					'Nette\Diagnostics\Debugger::getBlueScreen()->addPanel(?);',
-					Nette\DI\Compiler::filterArguments(array($item))
-				));
-			}
+		foreach ((array) $config['debugger']['blueScreen'] as $item) {
+			$initialize->addBody($container->formatPhp(
+				'Nette\Diagnostics\Debugger::getBlueScreen()->addPanel(?);',
+				Nette\DI\Compiler::filterArguments(array($item))
+			));
 		}
 
 		if (!empty($container->parameters['tempDir'])) {


### PR DESCRIPTION
Problem: NetteExtension is not consistent with adding BlueScreen panels defined in configuration. It always adds panels for database. But those defined in `nette.debugger.blueScreen` only when debugMode is on.

Solution: Always add BlueScreen panels.

Follow up from https://github.com/Kdyby/Autowired/pull/12.
