### PR TITLE
Added missing @ to header() call in initialize

### DIFF
--- a/Nette/DI/Extensions/NetteExtension.php
+++ b/Nette/DI/Extensions/NetteExtension.php
@@ -449,7 +449,7 @@ class NetteExtension extends Nette\DI\CompilerExtension
 
 		foreach ($config['http']['headers'] as $key => $value) {
 			if ($value != NULL) { // intentionally ==
-				$initialize->addBody('header(?);', array("$key: $value"));
+				$initialize->addBody('@header(?);', array("$key: $value"));
 			}
 		}
 


### PR DESCRIPTION
To remain compatible, the header call should be silent if the headers were already outputed.

This is a big issue in tests, I know they can be disabled by config now, but this is better because it doesn't break anything.
