### PR TITLE
tests: added JSON extension

### DIFF
--- a/tests/php-unix.ini
+++ b/tests/php-unix.ini
@@ -1,6 +1,7 @@
 [PHP]
 ; extension_dir = "./ext"
 extension=memcache.so
+extension=json.so
 
 [Zend]
 ;zend_extension="./ext/zend_extension"


### PR DESCRIPTION
Since JSON is required by tests (for example in `Nette\Utils\Neon`), I'm adding `json.so` to the list of extensions in `php-unix.ini`.

Without it, running tests may cause fatal error:

```
Fatal error: Call to undefined function Nette\Utils\json_encode()
```

Thx
