### PR TITLE
PresenterFactory: added onCreate event

### DIFF
--- a/Nette/Application/Application.php
+++ b/Nette/Application/Application.php
@@ -43,6 +43,9 @@ class Application extends Nette\Object
 
 	/** @var array of function(Application $sender, Request $request); Occurs when a new request is received */
 	public $onRequest;
+	
+	/** @var array of function(Application $sender, Presenter $presenter); Occurs when a presenter is created */
+	public $onPresenter;	
 
 	/** @var array of function(Application $sender, IResponse $response); Occurs when a new response is ready for dispatch */
 	public $onResponse;
@@ -146,6 +149,7 @@ class Application extends Nette\Object
 		$this->onRequest($this, $request);
 
 		$this->presenter = $this->presenterFactory->createPresenter($request->getPresenterName());
+		$this->onPresenter($this, $this->presenter);
 		$response = $this->presenter->run($request);
 
 		if ($response instanceof Responses\ForwardResponse) {


### PR DESCRIPTION
This is handy e.g. for IBarPanels which extends from UI\Control and need to be attached to presenter. Without this panel have to be passed to BasePresenter and attached manually and as we know, BasePresenter is antipattern :wink: 
