### PR TITLE
RouteList: do not change name of MicroPresenter

### DIFF
--- a/Nette/Application/Routers/RouteList.php
+++ b/Nette/Application/Routers/RouteList.php
@@ -44,7 +44,10 @@ class RouteList extends Nette\ArrayList implements Nette\Application\IRouter
 		foreach ($this as $route) {
 			$appRequest = $route->match($httpRequest);
 			if ($appRequest !== NULL) {
-				$appRequest->setPresenterName($this->module . $appRequest->getPresenterName());
+				$name = $appRequest->getPresenterName();
+				if ($name !== 'Nette:Micro') {
+					$appRequest->setPresenterName($this->module . $name);
+				}
 				return $appRequest;
 			}
 		}


### PR DESCRIPTION
this allows using micro presenter in module routers. otherwise it will prepend Nette:Micro with the module name
