### PR TITLE
netteForms.js: fixed validator FILLED for file inputs

### DIFF
--- a/client-side/netteForms.js
+++ b/client-side/netteForms.js
@@ -230,7 +230,7 @@ Nette.validateRule = function(elem, op, arg) {
 
 Nette.validators = {
 	filled: function(elem, arg, val) {
-		return val !== '' && val !== false && val !== null;
+		return val !== '' && val !== false && val !== null && (!window.FileList || !val instanceof FileList || val.length > 0);
 	},
 
 	blank: function(elem, arg, val) {


### PR DESCRIPTION
getValue() returns FileList for file inputs in supporting browsers, but the FILLED validator didn't take that into account, always evaluating as true.
