### PR TITLE
Forms: Fixed call to undefined method

### DIFF
--- a/Nette/Forms/Form.php
+++ b/Nette/Forms/Form.php
@@ -529,7 +529,7 @@ class Form extends Container
 	public function getAllErrors()
 	{
 		trigger_error(__METHOD__ . '() is deprecated; use getErrors() instead.', E_USER_DEPRECATED);
-		return $this->errors();
+		return $this->getErrors();
 	}
 
 


### PR DESCRIPTION
This fatal error is something that got into 2.1 stable as well, because its release was rushed and was not tested enough by end users.
