### PR TITLE
Dumper is displaying wrong file when called with shortcut dump()

### DIFF
--- a/Nette/Diagnostics/Dumper.php
+++ b/Nette/Diagnostics/Dumper.php
@@ -294,7 +294,8 @@ class Dumper
 	private static function findLocation()
 	{
 		foreach (debug_backtrace(PHP_VERSION_ID >= 50306 ? DEBUG_BACKTRACE_IGNORE_ARGS : FALSE) as $item) {
-			if (isset($item['file']) && strpos($item['file'], __DIR__) === 0) {
+			if (isset($item['file']) && (strpos($item['file'], __DIR__) === 0
+					|| strpos($item['file'], 'shortcuts.php') === strlen($item['file']) - 13)) {
 				continue;
 
 			} elseif (!isset($item['file'], $item['line']) || !is_file($item['file'])) {


### PR DESCRIPTION
allways displays `shortcuts.php` as it is in another directory than Dumper

wanted to simply do `dirname(__DIR__)` first, but then realized, that the file would be wrong always when somebody try to dump something anywhere in the whole Nette itself
