### PR TITLE
tests: set session.save_path in bootstrap

### DIFF
--- a/tests/Nette/Forms/Controls.CsrfProtection.phpt
+++ b/tests/Nette/Forms/Controls.CsrfProtection.phpt
@@ -13,9 +13,6 @@ use Nette\Forms\Form,
 require __DIR__ . '/../bootstrap.php';
 
 
-ini_set('session.save_path', TEMP_DIR);
-
-
 $_SERVER['REQUEST_METHOD'] = 'POST';
 
 

--- a/tests/Nette/Http/Session.handler.phpt
+++ b/tests/Nette/Http/Session.handler.phpt
@@ -15,9 +15,6 @@ use Nette\Object,
 require __DIR__ . '/../bootstrap.php';
 
 
-ini_set('session.save_path', TEMP_DIR);
-
-
 class MySessionStorage extends Object implements SessionHandlerInterface
 {
 	private $path;

--- a/tests/Nette/Http/Session.regenerateId().phpt
+++ b/tests/Nette/Http/Session.regenerateId().phpt
@@ -13,9 +13,6 @@ use Nette\Http\Session,
 require __DIR__ . '/../bootstrap.php';
 
 
-ini_set('session.save_path', TEMP_DIR);
-
-
 $container = id(new Nette\Configurator)->setTempDirectory(TEMP_DIR)->createContainer();
 $session = $container->getService('session');
 

--- a/tests/Nette/Http/Session.sections.phpt
+++ b/tests/Nette/Http/Session.sections.phpt
@@ -14,9 +14,6 @@ use Nette\Http\Session,
 require __DIR__ . '/../bootstrap.php';
 
 
-ini_set('session.save_path', TEMP_DIR);
-
-
 ob_start();
 
 $container = id(new Nette\Configurator)->setTempDirectory(TEMP_DIR)->createContainer();

--- a/tests/Nette/Http/Session.start.error.phpt
+++ b/tests/Nette/Http/Session.start.error.phpt
@@ -14,7 +14,6 @@ use Nette\Http\Session,
 require __DIR__ . '/../bootstrap.php';
 
 
-ini_set('session.gc_probability', 0); // ensure to GC not run
 ini_set('session.save_path', ';;;');
 
 

--- a/tests/Nette/Http/Session.storage.phpt
+++ b/tests/Nette/Http/Session.storage.phpt
@@ -15,9 +15,6 @@ use Nette\Object,
 require __DIR__ . '/../bootstrap.php';
 
 
-ini_set('session.save_path', TEMP_DIR);
-
-
 class MySessionStorage extends Object implements ISessionStorage
 {
 	private $path;

--- a/tests/Nette/Http/SessionSection.basic.phpt
+++ b/tests/Nette/Http/SessionSection.basic.phpt
@@ -13,9 +13,6 @@ use Nette\Http\Session,
 require __DIR__ . '/../bootstrap.php';
 
 
-ini_set('session.save_path', TEMP_DIR);
-
-
 $container = id(new Nette\Configurator)->setTempDirectory(TEMP_DIR)->createContainer();
 $session = $container->getService('session');
 

--- a/tests/Nette/Http/SessionSection.remove.phpt
+++ b/tests/Nette/Http/SessionSection.remove.phpt
@@ -13,9 +13,6 @@ use Nette\Http\Session,
 require __DIR__ . '/../bootstrap.php';
 
 
-ini_set('session.save_path', TEMP_DIR);
-
-
 $container = id(new Nette\Configurator)->setTempDirectory(TEMP_DIR)->createContainer();
 $session = $container->getService('session');
 

--- a/tests/Nette/Http/SessionSection.separated.phpt
+++ b/tests/Nette/Http/SessionSection.separated.phpt
@@ -13,9 +13,6 @@ use Nette\Http\Session,
 require __DIR__ . '/../bootstrap.php';
 
 
-ini_set('session.save_path', TEMP_DIR);
-
-
 $container = id(new Nette\Configurator)->setTempDirectory(TEMP_DIR)->createContainer();
 $session = $container->getService('session');
 

--- a/tests/Nette/Http/SessionSection.setExpiration().phpt
+++ b/tests/Nette/Http/SessionSection.setExpiration().phpt
@@ -13,9 +13,6 @@ use Nette\Http\Session,
 require __DIR__ . '/../bootstrap.php';
 
 
-ini_set('session.save_path', TEMP_DIR);
-
-
 $container = id(new Nette\Configurator)->setTempDirectory(TEMP_DIR)->createContainer();
 $session = $container->getService('session');
 

--- a/tests/Nette/Http/SessionSection.undefined.phpt
+++ b/tests/Nette/Http/SessionSection.undefined.phpt
@@ -13,9 +13,6 @@ use Nette\Http\Session,
 require __DIR__ . '/../bootstrap.php';
 
 
-ini_set('session.save_path', TEMP_DIR);
-
-
 $container = id(new Nette\Configurator)->setTempDirectory(TEMP_DIR)->createContainer();
 $session = $container->getService('session');
 

--- a/tests/Nette/bootstrap.php
+++ b/tests/Nette/bootstrap.php
@@ -23,6 +23,7 @@ define('TEMP_DIR', __DIR__ . '/../tmp/' . getmypid());
 @mkdir(dirname(TEMP_DIR)); // @ - directory may already exist
 Tester\Helpers::purge(TEMP_DIR);
 
+ini_set('session.save_path', TEMP_DIR);
 
 $_SERVER = array_intersect_key($_SERVER, array_flip(array('PHP_SELF', 'SCRIPT_NAME', 'SERVER_ADDR', 'SERVER_SOFTWARE', 'HTTP_HOST', 'DOCUMENT_ROOT', 'OS', 'argc', 'argv')));
 $_SERVER['REQUEST_TIME'] = 1234567890;


### PR DESCRIPTION
Two tests `Session.invalidId.phpt` and `User.authentication.phpt` (does not contain session.save_path setting as others) failed to me due to GC tried to clean system directory. And I noted that system dir is filled by test sessions.

This prevents it.
