### PR TITLE
Forms: 'out of range' exception contains name of field

### DIFF
--- a/Nette/Forms/Controls/ChoiceControl.php
+++ b/Nette/Forms/Controls/ChoiceControl.php
@@ -59,7 +59,7 @@ abstract class ChoiceControl extends BaseControl
 	public function setValue($value)
 	{
 		if ($value !== NULL && !isset($this->items[(string) $value])) {
-			throw new Nette\InvalidArgumentException("Value '$value' is out of range of current items.");
+			throw new Nette\InvalidArgumentException("Value '$value' is out of range of current items in '{$this->name}' field.");
 		}
 		$this->value = $value === NULL ? NULL : key(array((string) $value => NULL));
 		return $this;

--- a/Nette/Forms/Controls/MultiChoiceControl.php
+++ b/Nette/Forms/Controls/MultiChoiceControl.php
@@ -68,7 +68,7 @@ abstract class MultiChoiceControl extends BaseControl
 		}
 		$values = array_keys($flip);
 		if ($diff = array_diff($values, array_keys($this->items))) {
-			throw new Nette\InvalidArgumentException("Values '" . implode("', '", $diff) . "' are out of range of current items.");
+			throw new Nette\InvalidArgumentException("Values '" . implode("', '", $diff) . "' are out of range of current items in '{$this->name}' field.");
 		}
 		$this->value = $values;
 		return $this;

--- a/tests/Nette/Forms/Controls.CheckboxList.loadData.phpt
+++ b/tests/Nette/Forms/Controls.CheckboxList.loadData.phpt
@@ -138,7 +138,7 @@ test(function() use ($series) { // setValue() and invalid argument
 
 	Assert::exception(function() use ($input) {
 		$input->setValue('unknown');
-	}, 'Nette\InvalidArgumentException', "Values 'unknown' are out of range of current items.");
+	}, 'Nette\InvalidArgumentException', "Values 'unknown' are out of range of current items in 'list' field.");
 });
 
 

--- a/tests/Nette/Forms/Controls.ChoiceControl.loadData.phpt
+++ b/tests/Nette/Forms/Controls.ChoiceControl.loadData.phpt
@@ -143,7 +143,7 @@ test(function() use ($series) { // setValue() and invalid argument
 
 	Assert::exception(function() use ($input) {
 		$input->setValue('unknown');
-	}, 'Nette\InvalidArgumentException', "Value 'unknown' is out of range of current items.");
+	}, 'Nette\InvalidArgumentException', "Value 'unknown' is out of range of current items in 'select' field.");
 });
 
 

--- a/tests/Nette/Forms/Controls.MultiChoiceControl.loadData.phpt
+++ b/tests/Nette/Forms/Controls.MultiChoiceControl.loadData.phpt
@@ -142,7 +142,7 @@ test(function() use ($series) { // setValue() and invalid argument
 
 	Assert::exception(function() use ($input) {
 		$input->setValue('unknown');
-	}, 'Nette\InvalidArgumentException', "Values 'unknown' are out of range of current items.");
+	}, 'Nette\InvalidArgumentException', "Values 'unknown' are out of range of current items in 'select' field.");
 });
 
 

--- a/tests/Nette/Forms/Controls.MultiSelectBox.loadData.phpt
+++ b/tests/Nette/Forms/Controls.MultiSelectBox.loadData.phpt
@@ -188,7 +188,7 @@ test(function() use ($series) { // setValue() and invalid argument
 
 	Assert::exception(function() use ($input) {
 		$input->setValue('unknown');
-	}, 'Nette\InvalidArgumentException', "Values 'unknown' are out of range of current items.");
+	}, 'Nette\InvalidArgumentException', "Values 'unknown' are out of range of current items in 'select' field.");
 });
 
 

--- a/tests/Nette/Forms/Controls.RadioList.loadData.phpt
+++ b/tests/Nette/Forms/Controls.RadioList.loadData.phpt
@@ -138,7 +138,7 @@ test(function() use ($series) { // setValue() and invalid argument
 
 	Assert::exception(function() use ($input) {
 		$input->setValue('unknown');
-	}, 'Nette\InvalidArgumentException', "Value 'unknown' is out of range of current items.");
+	}, 'Nette\InvalidArgumentException', "Value 'unknown' is out of range of current items in 'radio' field.");
 });
 
 

--- a/tests/Nette/Forms/Controls.SelectBox.loadData.phpt
+++ b/tests/Nette/Forms/Controls.SelectBox.loadData.phpt
@@ -198,7 +198,7 @@ test(function() use ($series) { // setValue() and invalid argument
 
 	Assert::exception(function() use ($input) {
 		$input->setValue('unknown');
-	}, 'Nette\InvalidArgumentException', "Value 'unknown' is out of range of current items.");
+	}, 'Nette\InvalidArgumentException', "Value 'unknown' is out of range of current items in 'select' field.");
 });
 
 


### PR DESCRIPTION
When this error occurs using `$form->setDefaults()` method on really big form, it can be quite difficult to find out which field caused the problem.
