### PR TITLE
netteForms.js: Added image file type validation

### DIFF
--- a/client-side/netteForms.js
+++ b/client-side/netteForms.js
@@ -332,6 +332,17 @@ Nette.validators = {
 			}
 		}
 		return true;
+	},
+	image: function (elem, arg, val) {
+		if (window.FileList && val instanceof FileList) {
+			for (var i = 0; i < val.length; i++) {
+				var type = val[i].type;
+				if (type && type !== 'image/gif' && type !== 'image/png' && type !== 'image/jpeg') {
+					return false;
+				}
+			}
+		}
+		return true;
 	}
 };
 


### PR DESCRIPTION
This adds a client-side validation for images (`Form::IMAGE` in form definition).

I would appreciate some testing first, I will try to test it myself in some browsers.
