### PR TITLE
TextBase: set maxlength to the lowest allowed value

### DIFF
--- a/Nette/Forms/Controls/TextBase.php
+++ b/Nette/Forms/Controls/TextBase.php
@@ -115,7 +115,9 @@ abstract class TextBase extends BaseControl
 	{
 		if ($validator === Form::LENGTH || $validator === Form::MAX_LENGTH) {
 			$tmp = is_array($arg) ? $arg[1] : $arg;
-			$this->control->maxlength = is_scalar($tmp) ? $tmp : NULL;
+			if (is_scalar($tmp)) {
+				$this->control->maxlength = isset($this->control->maxlength) ? min($this->control->maxlength, $tmp) : $tmp;
+			}
 		}
 		return parent::addRule($validator, $message, $arg);
 	}

--- a/tests/Nette/Forms/Controls.TextArea.render.phpt
+++ b/tests/Nette/Forms/Controls.TextArea.render.phpt
@@ -73,9 +73,10 @@ test(function() { // validation rule LENGTH
 test(function() { // validation rule MAX_LENGTH
 	$form = new Form;
 	$input = $form->addTextArea('text')
+		->addRule($form::MAX_LENGTH, NULL, 30)
 		->addRule($form::MAX_LENGTH, NULL, 10);
 
-	Assert::same('<textarea name="text" maxlength="10" id="frm-text" data-nette-rules=\'[{"op":":maxLength","msg":"Please enter no more than 10 characters.","arg":10}]\'></textarea>', (string) $input->getControl());
+	Assert::same('<textarea name="text" maxlength="10" id="frm-text" data-nette-rules=\'[{"op":":maxLength","msg":"Please enter no more than 30 characters.","arg":30},{"op":":maxLength","msg":"Please enter no more than 10 characters.","arg":10}]\'></textarea>', (string) $input->getControl());
 });
 
 

--- a/tests/Nette/Forms/Controls.TextInput.render.phpt
+++ b/tests/Nette/Forms/Controls.TextInput.render.phpt
@@ -91,9 +91,17 @@ test(function() { // conditional required
 });
 
 
+test(function() { // maxlength without validation rule
+	$form = new Form;
+	$input = $form->addText('text', NULL, NULL, 30);
+
+	Assert::same('<input type="text" name="text" maxlength="30" id="frm-text" value="">', (string) $input->getControl());
+});
+
+
 test(function() { // validation rule LENGTH
 	$form = new Form;
-	$input = $form->addText('text')
+	$input = $form->addText('text', NULL, NULL, 30)
 		->addRule($form::LENGTH, NULL, array(10, 20));
 
 	Assert::same('<input type="text" name="text" maxlength="20" id="frm-text" data-nette-rules=\'[{"op":":length","msg":"Please enter a value between 10 and 20 characters long.","arg":[10,20]}]\' value="">', (string) $input->getControl());
@@ -102,7 +110,7 @@ test(function() { // validation rule LENGTH
 
 test(function() { // validation rule MAX_LENGTH
 	$form = new Form;
-	$input = $form->addText('text')
+	$input = $form->addText('text', NULL, NULL, 30)
 		->addRule($form::MAX_LENGTH, NULL, 10);
 
 	Assert::same('<input type="text" name="text" maxlength="10" id="frm-text" data-nette-rules=\'[{"op":":maxLength","msg":"Please enter no more than 10 characters.","arg":10}]\' value="">', (string) $input->getControl());


### PR DESCRIPTION
This fixes a similar issue as #1335. Maxlength attribute should be set to the lowest allowed value.
