### PR TITLE
Add support for HTML5 input types search and tel

### DIFF
--- a/Nette/Forms/Container.php
+++ b/Nette/Forms/Container.php
@@ -255,6 +255,21 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 
 	/**
+	 * Adds single-line telephone input control to the form.
+	 * @param  string  control name
+	 * @param  string  label
+	 * @param  int  maximum number of characters the user may enter
+	 * @return Nette\Forms\Controls\TextInput
+	 */
+	public function addTelephone($name, $label = NULL, $maxLength = NULL)
+	{
+		$control = new Controls\TextInput($label, $maxLength);
+		$control->setType('tel');
+		return $this[$name] = $control;
+	}
+
+
+	/**
 	 * Adds single-line text input control used for sensitive input such as passwords.
 	 * @param  string  control name
 	 * @param  string  label

--- a/Nette/Forms/Container.php
+++ b/Nette/Forms/Container.php
@@ -240,6 +240,21 @@ class Container extends Nette\ComponentModel\Container implements \ArrayAccess
 
 
 	/**
+	 * Adds single-line search input control to the form.
+	 * @param  string  control name
+	 * @param  string  label
+	 * @param  int  maximum number of characters the user may enter
+	 * @return Nette\Forms\Controls\TextInput
+	 */
+	public function addSearch($name, $label = NULL, $maxLength = NULL)
+	{
+		$control = new Controls\TextInput($label, $maxLength);
+		$control->setType('search');
+		return $this[$name] = $control;
+	}
+
+
+	/**
 	 * Adds single-line text input control used for sensitive input such as passwords.
 	 * @param  string  control name
 	 * @param  string  label

--- a/tests/Nette/Forms/Controls.TextInput.render.phpt
+++ b/tests/Nette/Forms/Controls.TextInput.render.phpt
@@ -71,6 +71,15 @@ test(function() { // password
 });
 
 
+test(function() { // search
+	$form = new Form;
+	$input = $form->addSearch('search')
+		->setValue('rtfm');
+
+	Assert::same('<input type="search" name="search" id="frm-search" value="rtfm">', (string) $input->getControl());
+});
+
+
 test(function() { // validation rule required & PATTERN
 	$form = new Form;
 	$input = $form->addText('text')

--- a/tests/Nette/Forms/Controls.TextInput.render.phpt
+++ b/tests/Nette/Forms/Controls.TextInput.render.phpt
@@ -80,6 +80,15 @@ test(function() { // search
 });
 
 
+test(function() { // telephone
+	$form = new Form;
+	$input = $form->addTelephone('telephone')
+		->setValue('112');
+
+	Assert::same('<input type="tel" name="telephone" id="frm-telephone" value="112">', (string) $input->getControl());
+});
+
+
 test(function() { // validation rule required & PATTERN
 	$form = new Form;
 	$input = $form->addText('text')


### PR DESCRIPTION
Both type=tel and type=search inputs are essentially the same as standard type=text. The main difference is semantic.