### PR TITLE
TextInput: Export pattern, min and max attributes only if the input type allows them

### DIFF
--- a/Nette/Forms/Controls/TextInput.php
+++ b/Nette/Forms/Controls/TextInput.php
@@ -61,11 +61,13 @@ class TextInput extends TextBase
 	public function getControl()
 	{
 		$input = parent::getControl();
+		$exportPattern = in_array($input->type, array('text', 'search', 'tel', 'url', 'email', 'password'));
+		$exportRange = in_array($input->type, array('number', 'range', 'datetime-local', 'datetime', 'date', 'month', 'week', 'time'));
 
 		foreach ($this->getRules() as $rule) {
 			if ($rule->isNegative || $rule->branch) {
 
-			} elseif (in_array($rule->validator, array(Form::MIN, Form::MAX, Form::RANGE)) && $input->type !== 'text') {
+			} elseif ($exportRange && in_array($rule->validator, array(Form::MIN, Form::MAX, Form::RANGE))) {
 				if ($rule->validator === Form::MIN) {
 					$range = array($rule->arg, NULL);
 				} elseif ($rule->validator === Form::MAX) {
@@ -80,8 +82,8 @@ class TextInput extends TextBase
 					$input->max = isset($input->max) ? min($input->max, $range[1]) : $range[1];
 				}
 
-			} elseif ($rule->validator === Form::PATTERN && is_scalar($rule->arg)) {
-				$input->pattern = $rule->arg;
+			} elseif ($exportPattern && $rule->validator === Form::PATTERN && is_scalar($rule->arg)) {
+				$input->pattern = '\s*(?:' . $rule->arg . ')\s*';
 			}
 		}
 

--- a/tests/Nette/Forms/Controls.TextInput.render.phpt
+++ b/tests/Nette/Forms/Controls.TextInput.render.phpt
@@ -77,7 +77,10 @@ test(function() { // validation rule required & PATTERN
 		->setRequired('required')
 		->addRule($form::PATTERN, 'error message', '[0-9]+');
 
-	Assert::same('<input type="text" name="text" id="frm-text" required data-nette-rules=\'[{"op":":filled","msg":"required"},{"op":":pattern","msg":"error message","arg":"[0-9]+"}]\' pattern="[0-9]+" value="">', (string) $input->getControl());
+	foreach (array('text', 'password', 'search', 'tel', 'url', 'email') as $type) {
+		$input->setType($type);
+		Assert::same('<input type="' . $type . '" name="text" id="frm-text" required data-nette-rules=\'[{"op":":filled","msg":"required"},{"op":":pattern","msg":"error message","arg":"[0-9]+"}]\' pattern="\s*(?:[0-9]+)\s*"' . ($type === 'password' ? '' : ' value=""'). '>', (string) $input->getControl());
+	}
 });
 
 
@@ -109,7 +112,21 @@ test(function() { // validation rule MAX_LENGTH
 });
 
 
-test(function() { // validation rule RANGE & setType
+test(function() { // validation rule RANGE without setType
+	$form = new Form;
+	$minInput = $form->addText('min');
+	$maxInput = $form->addText('max');
+	$input = $form->addText('count')
+		->addRule(Form::RANGE, 'Must be in range from %d to %d', array(0, 100))
+		->addRule(Form::MIN, 'Must be greater than or equal to %d', 1)
+		->addRule(Form::MAX, 'Must be less than or equal to %d', 101)
+		->addRule(Form::RANGE, 'Must be in range from %d to %d', array($minInput, $maxInput));
+
+	Assert::same('<input type="text" name="count" id="frm-count" data-nette-rules=\'[{"op":":range","msg":"Must be in range from 0 to 100","arg":[0,100]},{"op":":min","msg":"Must be greater than or equal to 1","arg":1},{"op":":max","msg":"Must be less than or equal to 101","arg":101},{"op":":range","msg":"Must be in range from %0 to %1","arg":[{"control":"min"},{"control":"max"}]}]\' value="">', (string) $input->getControl());
+});
+
+
+test(function() { // validation rule RANGE with setType
 	$form = new Form;
 	$minInput = $form->addText('min');
 	$maxInput = $form->addText('max');


### PR DESCRIPTION
Not all types of inputs allow pattern, min and max attributes (see http://www.w3.org/TR/html5/forms.html#input-type-attr-summary). Furthermore, regular expression in pattern attribute is now exported ~~as anchored~~ with added trailing whitespaces to make it consistent with Nette validation.
