### PR TITLE
Forms: Completely strip line breaks from DATA_LINE fields.

### DIFF
--- a/Nette/Forms/Helpers.php
+++ b/Nette/Forms/Helpers.php
@@ -58,7 +58,7 @@ class Helpers extends Nette\Object
 			return is_scalar($value) ? Strings::normalizeNewLines($value) : NULL;
 
 		} elseif ($type === Form::DATA_LINE) {
-			return is_scalar($value) ? Strings::trim(strtr($value, "\r\n", '  ')) : NULL;
+			return is_scalar($value) ? Strings::trim(str_replace(array("\r", "\n"), '', $value)) : NULL;
 
 		} elseif ($type === Form::DATA_FILE) {
 			return $value instanceof Nette\Http\FileUpload ? $value : NULL;

--- a/tests/Nette/Forms/Controls.TextBase.loadData.phpt
+++ b/tests/Nette/Forms/Controls.TextBase.loadData.phpt
@@ -25,7 +25,7 @@ test(function() { // trim & new lines
 	$form = new Form;
 	$input = $form->addText('text');
 
-	Assert::same( 'a  b   c', $input->getValue() );
+	Assert::same( 'a b  c', $input->getValue() );
 	Assert::true( $input->isFilled() );
 });
 

--- a/tests/Nette/Forms/Helpers.extractHttpData.phpt
+++ b/tests/Nette/Forms/Helpers.extractHttpData.phpt
@@ -30,7 +30,7 @@ test(function() { // non-multiple
 	Assert::null( Helpers::extractHttpData(array('invalid' => array('')), 'invalid', Form::DATA_LINE));
 	Assert::null( Helpers::extractHttpData(array('invalid' => array('')), 'invalid', Form::DATA_TEXT));
 
-	Assert::same('a  b   c', Helpers::extractHttpData(array('text' => "  a\r b \n c "), 'text', Form::DATA_LINE));
+	Assert::same('a b  c', Helpers::extractHttpData(array('text' => "  a\r b \n c "), 'text', Form::DATA_LINE));
 	Assert::same("  a\n b \n c ", Helpers::extractHttpData(array('text' => "  a\r b \n c "), 'text', Form::DATA_TEXT));
 });
 
@@ -51,7 +51,7 @@ test(function() { // multiple
 	Assert::same(array(), Helpers::extractHttpData(array('invalid' => 'red-dwarf'), 'invalid[]', Form::DATA_LINE));
 	Assert::same(array(), Helpers::extractHttpData(array('invalid' => array(array(''))), 'invalid[]', Form::DATA_LINE));
 
-	Assert::same(array('a  b   c'), Helpers::extractHttpData(array('text' => array("  a\r b \n c ")), 'text[]', Form::DATA_LINE));
+	Assert::same(array('a b  c'), Helpers::extractHttpData(array('text' => array("  a\r b \n c ")), 'text[]', Form::DATA_LINE));
 	Assert::same(array("  a\n b \n c "), Helpers::extractHttpData(array('text' => array("  a\r b \n c ")), 'text[]', Form::DATA_TEXT));
 });
 


### PR DESCRIPTION
UA is supposed to remove line breaks from line inputs, in fact it must not allow the user to even input them. Server side sanitization should behave the same way.

References: http://www.w3.org/TR/html5/infrastructure.html#strip-line-breaks
# BC-break
