### PR TITLE
FileStorage: Cache file has permissions 666, so everyone can delete it

### DIFF
--- a/Nette/Caching/Storages/FileStorage.php
+++ b/Nette/Caching/Storages/FileStorage.php
@@ -150,6 +150,7 @@ class FileStorage extends Nette\Object implements Nette\Caching\IStorage
 		$handle = @fopen($cacheFile, 'r+b'); // @ - file may not exist
 		if (!$handle) {
 			$handle = fopen($cacheFile, 'wb');
+			chmod($cacheFile, 0666);
 			if (!$handle) {
 				return;
 			}


### PR DESCRIPTION
Situation on Debian:
When someone access web page, cache files for database are created, but with permissions 644, owner is Apache.
Then when I want to call action from console, it is permitted, because PHP is not an owner.
