### PR TITLE
Dumper: JS for nette-toggle doesn't collide with SVG

### DIFF
--- a/Nette/Diagnostics/templates/dumper.js
+++ b/Nette/Diagnostics/templates/dumper.js
@@ -27,7 +27,7 @@
 			}
 
 			// enables <a class="nette-toggle" href="#"> or <span data-ref="#"> toggling
-			for (link = e.target; link && (!link.tagName || link.className.indexOf('nette-toggle') < 0); link = link.parentNode) {}
+			for (link = e.target; link && (!link.tagName || typeof link.className !== 'string' || link.className.indexOf('nette-toggle') < 0); link = link.parentNode) {}
 			if (!link) {
 				return;
 			}


### PR DESCRIPTION
When I had SVG on page (generated with [Raphael.js](https://github.com/DmitryBaranovskiy/raphael/) library), clicking on the SVG element fired error in inlined `dumper.js`, because `elem.classList` of SVG element is instance of `SVGAnimatedString`, which doesn't have `indexOf()` method. Observed in Chrome 32.
