### PR TITLE
Added fallback parameter to detectLanguage

### DIFF
--- a/Nette/Http/Request.php
+++ b/Nette/Http/Request.php
@@ -293,13 +293,14 @@ class Request extends Nette\Object implements IRequest
 	/**
 	 * Parse Accept-Language header and returns prefered language.
 	 * @param  array   Supported languages
+	 * @param  string  Fallback language
 	 * @return string
 	 */
-	public function detectLanguage(array $langs)
+	public function detectLanguage(array $langs, $default = NULL)
 	{
 		$header = $this->getHeader('Accept-Language');
 		if (!$header) {
-			return NULL;
+			return $default;
 		}
 
 		$s = strtolower($header);  // case insensitive
@@ -308,7 +309,7 @@ class Request extends Nette\Object implements IRequest
 		preg_match_all('#(' . implode('|', $langs) . ')(?:-[^\s,;=]+)?\s*(?:;\s*q=([0-9.]+))?#', $s, $matches);
 
 		if (!$matches[0]) {
-			return NULL;
+			return $default;
 		}
 
 		$max = 0;


### PR DESCRIPTION
Today I uncovered problem in my application, I relied that detectLanguage method always returns a language. But if the language can not be determined, then returns null.

It can be solved as follows

``` php
$lang = $httpRequest->detectLanguage($languages);
if ($lang === NULL) {
    $lang = 'en';
}
```

Why not use a simpler

``` php
$lang = $httpRequest->detectLanguage($languages, 'en');
```
