### PR TITLE
Latte: fixed snippetArea with included template when snippetMode is disadled

### DIFF
--- a/Nette/Latte/Macros/UIMacros.php
+++ b/Nette/Latte/Macros/UIMacros.php
@@ -312,7 +312,7 @@ if (!empty($_control->snippetMode)) {
 
 			if (empty($node->data->leave)) {
 				if ($node->name === 'snippetArea') {
-					$node->content = "<?php \$_control->snippetMode = TRUE; ?>{$node->content}<?php \$_control->snippetMode = FALSE; ?>";
+					$node->content = "<?php \$_control->snippetMode = isset(\$_snippetMode) && \$_snippetMode; ?>{$node->content}<?php \$_control->snippetMode = FALSE; ?>";
 				}
 				if (!empty($node->data->dynamic)) {
 					$node->content .= '<?php if (isset($_dynSnippets)) return $_dynSnippets; ?>';
@@ -477,7 +477,7 @@ if (!empty($_control->snippetMode)) {
 				}
 				ob_start();
 				$function = reset($function);
-				$snippets = $function($local, $params);
+				$snippets = $function($local, $params + array('_snippetMode' => TRUE));
 				$payload->snippets[$id = $control->getSnippetId(substr($name, 1))] = ob_get_clean();
 				if ($snippets !== NULL) { // pass FALSE from snippetArea
 					if ($snippets) {

--- a/tests/Nette/Latte/UIMacros.renderSnippets.phpt
+++ b/tests/Nette/Latte/UIMacros.renderSnippets.phpt
@@ -97,3 +97,9 @@ Assert::same(array(
 		'snippet--array-3' => 'Value 3',
 	),
 ), (array) $presenter->payload);
+
+$presenter = new TestPresenter;
+ob_start();
+$presenter->render();
+$content = ob_get_clean();
+Assert::matchFile(__DIR__ .'/expected/UIMacros.renderSnippets.html', $content);

--- a/tests/Nette/Latte/expected/UIMacros.renderSnippets.html
+++ b/tests/Nette/Latte/expected/UIMacros.renderSnippets.html
@@ -1,0 +1,13 @@
+<div id="snippet--hello">Hello</div> world!
+
+<div id="snippet--include"><p>Included file #3 (A, B)</p>
+</div>
+<div id="snippet--array">		<div id="snippet--array-1">Value 1</div>
+		<div id="snippet--array-2">Value 2</div>
+		<div id="snippet--array-3">Value 3</div>
+</div>
+		<div id="snippet--array2-1">Value 1</div>
+		<div id="snippet--array2-2">Value 2</div>
+		<div id="snippet--array2-3">Value 3</div>
+
+<div id="snippet--includeSay">Hello include snippet</div>


### PR DESCRIPTION
When snippetArea contains included template then template was not rendered in non-ajax mode (when snippetMode is not enabled)
example code:

``` smarty
{snippetArea foo}
{include "foo.latte"}
{/snippetArea}
```

(content of foo.latte was not rendered)

This seems to work, but I don't like it. Do you have a better idea how to fix it?
