### PR TITLE
Forms: the CSRF token is protected against BREACH attack

### DIFF
--- a/Nette/Forms/Controls/CsrfProtection.php
+++ b/Nette/Forms/Controls/CsrfProtection.php
@@ -45,7 +45,7 @@ class CsrfProtection extends HiddenField
 	/**
 	 * @return string
 	 */
-	public function getToken()
+	protected function getToken()
 	{
 		$session = $this->getSession()->getSection(__CLASS__);
 		if (!isset($session->token)) {
@@ -56,13 +56,26 @@ class CsrfProtection extends HiddenField
 
 
 	/**
+	 * @param  string|NULL
+	 * @return string
+	 */
+	protected function generateToken($random = NULL)
+	{
+		if ($random === NULL) {
+			$random = Nette\Utils\Strings::random(10);
+		}
+		return $random . base64_encode(sha1($this->getToken() . $random, TRUE));
+	}
+
+
+	/**
 	 * Generates control's HTML element.
 	 *
 	 * @return Nette\Utils\Html
 	 */
 	public function getControl()
 	{
-		return parent::getControl()->value($this->getToken());
+		return parent::getControl()->value($this->generateToken());
 	}
 
 
@@ -71,7 +84,8 @@ class CsrfProtection extends HiddenField
 	 */
 	public static function validateCsrf(CsrfProtection $control)
 	{
-		return $control->getValue() === $control->getToken();
+		$value = $control->getValue();
+		return $control->generateToken(substr($value, 0, 10)) === $value;
 	}
 
 

--- a/tests/Nette/Forms/Controls.CsrfProtection.breachAttack.phpt
+++ b/tests/Nette/Forms/Controls.CsrfProtection.breachAttack.phpt
@@ -20,11 +20,11 @@ $input = $form->addProtection('Security token did not match. Possible CSRF attac
 
 $target = strlen($input->getControl()->value);
 
-$charlist = 'abcdefghijklmnopqrstuvwxyz0123456789';
+$charlist = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
 
 $strings = array();
-for ($a = 0; $a < 36; $a++) {
-	for ($b = 0; $b < 36; $b++) {
+for ($a = 0; $a < 65; $a++) {
+	for ($b = 0; $b < 65; $b++) {
 		$strings[] = $charlist[$a] . $charlist[$b];
 	}
 }
@@ -34,7 +34,7 @@ for ($i = 3; $i <= $target; $i++) {
 	$shortest = NULL;
 	$newStrings = array();
 	foreach ($strings as $string) {
-		for ($j = 0; $j < 36; $j++) {
+		for ($j = 0; $j < 65; $j++) {
 			$s = $string . $charlist[$j];
 			$length = strlen(gzdeflate($code . '<input type="text" value="' . $s . '">'));
 			if ($shortest === NULL || $length < $shortest) {

--- a/tests/Nette/Forms/Controls.CsrfProtection.phpt
+++ b/tests/Nette/Forms/Controls.CsrfProtection.phpt
@@ -6,7 +6,8 @@
  * @author     David Grudl
  */
 
-use Nette\Forms\Form,
+use Nette\Forms\Controls\CsrfProtection,
+	Nette\Forms\Form,
 	Tester\Assert;
 
 
@@ -24,3 +25,12 @@ $form->fireEvents();
 
 Assert::same( array('Security token did not match. Possible CSRF attack.'), $form->getErrors() );
 Assert::match('<input type="hidden" name="_token_" value="%S%">', (string) $input->getControl());
+
+$input->setValue(NULL);
+Assert::false(CsrfProtection::validateCsrf($input));
+
+$input->setValue('12345678901234567890123456789012345678');
+Assert::false(CsrfProtection::validateCsrf($input));
+
+$input->setValue($input->getControl()->value);
+Assert::true(CsrfProtection::validateCsrf($input));


### PR DESCRIPTION
Here's a nice demonstration of BREACH attack: http://resources.infosecinstitute.com/the-breach-attack/

~~The CSRF token is split into two parts (A and B). The part A is be always a new random string of the same length as the token. The part B is a XOR of the part A and the token. (We can easily reconstruct the token as a XOR of the parts A and B.) So the attacker cannot detect the CSRF token, because the parts A and B will be different on each request.~~ I simplified the [algorithm](https://github.com/nette/nette/pull/1378/files#diff-d6f3e4faa4c4aa64f9259cf7cbe0140fR58).
