### PR TITLE
Application: added CSRF protection for signals using method POST [Closes #469]

### DIFF
--- a/Nette/Application/UI/Presenter.php
+++ b/Nette/Application/UI/Presenter.php
@@ -1101,6 +1101,27 @@ abstract class Presenter extends Control implements Application\IPresenter
 	}
 
 
+	/********************* CSRF protection ****************d*g**/
+
+
+	/**
+	 * Displays confirmation dialog which prevents Cross-Site Request Forgery (CSRF).
+	 * @param  array
+	 * @param  string|NULL
+	 * @param  string|NULL
+	 * @return void
+	 */
+	public function displayCsrfConfirmationDialog(array $post, $question = NULL, $buttonCaption = NULL)
+	{
+		$template = new Nette\Templating\FileTemplate;
+		$template->setFile(__DIR__ . '/templates/confirmationDialog.phtml');
+		$template->post = $post;
+		$template->question = $question;
+		$template->buttonCaption = $buttonCaption;
+		$this->sendResponse(new Responses\TextResponse($template));
+	}
+
+
 	/********************* interface IStatePersistent ****************d*g**/
 
 

--- a/Nette/Application/UI/templates/confirmationDialog.phtml
+++ b/Nette/Application/UI/templates/confirmationDialog.phtml
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Confirmation dialog which prevents Cross-Site Request Forgery (CSRF).
+ * @param  array  $post
+ * @param  string $question
+ * @param  string $buttonCaption
+ */
+
+
+?>
+<!DOCTYPE html>
+<meta charset="utf-8">
+<meta name=robots content=noindex>
+<meta name=generator content="Nette Framework">
+<style>
+    body { color: #333; background: white; width: 600px; margin: 100px auto }
+    h1 { font: bold 47px/1.5 sans-serif; margin: .6em 0 }
+    p { font: 21px/1.5 Georgia,serif; margin: 1.5em 0 }
+</style>
+
+<title>Confirmation Required</title>
+
+<h1>Confirmation Required</h1>
+
+<p><?php echo htmlspecialchars($question ?: 'Are you sure you want to do this action?') ?></p>
+
+<form action="" method="post">
+	<p>
+		<input type="submit" value="<?php echo htmlspecialchars($buttonCaption ?: 'Yes') ?>">
+	</p>
+	<?php foreach ($post as $key => $val): ?>
+		<input type="hidden" name="<?php echo htmlspecialchars($key) ?>" value="<?php echo htmlspecialchars($val) ?>">
+	<?php endforeach ?>
+</form>
+
+<p>If you did not request any action, do not click the button and leave this page immediately.</p>

--- a/Nette/Latte/Macros/UIMacros.php
+++ b/Nette/Latte/Macros/UIMacros.php
@@ -57,6 +57,7 @@ class UIMacros extends MacroSet
 		$me->addMacro('plink', array($me, 'macroLink'));
 		$me->addMacro('link', array($me, 'macroLink'));
 		$me->addMacro('ifCurrent', array($me, 'macroIfCurrent'), '}'); // deprecated; use n:class="$presenter->linkCurrent ? ..."
+		$me->addMacro('secured', NULL, NULL, array($me, 'macroSecured'));
 
 		$me->addMacro('contentType', array($me, 'macroContentType'));
 		$me->addMacro('status', array($me, 'macroStatus'));
@@ -388,6 +389,15 @@ if (!empty($_control->snippetMode)) {
 	{
 		return $writer->write(($node->args ? 'try { $_presenter->link(%node.word, %node.array?); } catch (Nette\Application\UI\InvalidLinkException $e) {}' : '')
 			. '; if ($_presenter->getLastCreatedRequestFlag("current")) {');
+	}
+
+
+	/**
+	 * n:secured
+	 */
+	public function macroSecured(MacroNode $node, PhpWriter $writer)
+	{
+		return $writer->write('?> data-nette-post="<?php echo htmlspecialchars(Nette\Utils\Json::encode($control->getCsrfPost())) ?>"<?php');
 	}
 
 


### PR DESCRIPTION
The [RFC 2616, section 9.1.1](http://tools.ietf.org/search/rfc2616#section-9.1.1) states:

> In particular, the convention has been established that the GET and HEAD methods SHOULD NOT have the significance of taking an action other than retrieval. These methods ought to be considered "safe". This allows user agents to represent other methods, such as POST, PUT and DELETE, in a special way, so that the user is made aware of the fact that a possibly unsafe action is being requested.

So we should use POST for secured signals (and ideally for all signals with side effects).

We can do this using a JavaScript, that sends links with parameter `data-nette-post` using POST. We can also easily create a fallback method for users without JavaScript - if an user attempts to access a protected page using GET method, we will show him a confirmation form which will execute the request with the CSRF token in POST param.

This commit allows you to protect signal by calling e.g. `$this->addProtection("Do you really want to delete user '$username'?");` at the beggining of the signal. After that, if you access the page via GET or via POST but with an invalid token, a confirmation dialog will be displayed.

A secured link can be created using `<a n:href="signal!" n:secured>`, which adds the parameter `data-nette-post`. You can send links with this parameter by method POST using the following JavaScript:

```
jQuery(function($) {
    $(document).on("click", "a[data-nette-post]", function(event) {
        var form = document.createElement("form");
        form.method = "POST";
        form.action = this.href;
        form.style.display = "none";
        var post = $(this).data("nette-post");
        for (var key in post) {
            var input = document.createElement("input");
            input.setAttribute("type", "hidden");
            input.setAttribute("name", key);
            input.setAttribute("value", post[key]);
            form.appendChild(input);
        }
        $(form).submit();
        event.preventDefault();
    });
});
```

(Maybe we should also create some official JavaScript like netteForms.js.)

If you want to send signals using AJAX, you have to just modify your JavaScript, so that it will use method POST and send POST params contained in `$control->getCsrfPost()`.

The confirmation dialog can be customized by overriding the method `displayCsrfConfirmationDialog()` in Presenter.
