### PR TITLE
Recursive argument parsing

### DIFF
--- a/Nette/DI/Compiler.php
+++ b/Nette/DI/Compiler.php
@@ -352,7 +352,9 @@ class Compiler extends Nette\Object
 		foreach ($args as $k => $v) {
 			if ($v === '...') {
 				unset($args[$k]);
-			} elseif ($v instanceof \stdClass && isset($v->value, $v->attributes)) {
+			} elseif (is_array($v)){
+                		$args[$k] = self::filterArguments($v);
+        		} elseif ($v instanceof \stdClass && isset($v->value, $v->attributes)) {
 				$args[$k] = new Statement($v->value, self::filterArguments($v->attributes));
 			}
 		}

--- a/tests/Nette/DI/Compiler.filterArguments.phpt
+++ b/tests/Nette/DI/Compiler.filterArguments.phpt
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Test: Nette\DI\Compiler: filtering arguments 
+ *
+ * @author     Alexandru Pitis
+ * @package    Nette\DI
+ */
+
+use Nette\DI,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$compiler = new DI\Compiler;
+
+
+$args = array();
+$testOneInput = array();
+$testOneClassOne = new stdClass;
+$testOneClassOne->value = '\Namespace\TestClass';
+$testOneClassOne->attributes = array('constantArgument','%configArgument%');
+
+$testOneClassTwo = new stdClass;
+$testOneClassTwo->value = '\Namespace\AnotherClass';
+$testOneClassTwo->attributes = array();
+
+$args[] = $testOneClassOne;
+$args[] = $testOneClassTwo;
+
+$testOneOutput = array(
+
+	new Nette\DI\Statement($testOneClassOne->value,$testOneClassOne->attributes),
+	new Nette\DI\Statement($testOneClassTwo->value,$testOneClassTwo->attributes),
+	
+);
+
+Assert::equal($testOneOutput,$compiler::filterArguments($args));
+
+$args = array();
+$testTwoInput = array();
+$testTwoClassOne = new stdClass;
+$testTwoClassOne->value = '\Namespace\SuperClass::runSomethingSpecial';
+$testTwoClassOne->attributes = array('constantArgument','%configArgument%');
+
+$testTwoClassTwo = new stdClass;
+$testTwoClassTwo->value = '\Namespace\BlankClass';
+$testTwoClassTwo->attributes = array();
+
+$testTwoClassThree = new stdClass;
+$testTwoClassThree->value = '\Namespace\AnotherBlankClass';
+$testTwoClassThree->attributes = array();
+
+$testTwoClassFour = new stdClass;
+$testTwoClassFour->value = '\Namespace\SomeClassInstance::runSomething';
+$testTwoClassFour->attributes = array('testData');
+
+$testTwoNestedArguments = array('test' => $testTwoClassThree, 'test2' => $testTwoClassFour);
+
+$args[] = $testTwoClassOne;
+$args[] = $testTwoClassTwo;
+$args[] = $testTwoNestedArguments;
+
+$testTwoOutput = array(
+
+	new Nette\DI\Statement($testTwoClassOne->value,$testTwoClassOne->attributes),
+	new Nette\DI\Statement($testTwoClassTwo->value,$testTwoClassTwo->attributes),
+	array('test' => new Nette\DI\Statement($testTwoClassThree->value,$testTwoClassThree->attributes), 'test2' => new Nette\DI\Statement($testTwoClassFour->value,$testTwoClassFour->attributes))
+);
+
+
+Assert::equal($testTwoOutput,$compiler::filterArguments($args));


### PR DESCRIPTION
Allows for recursive argument parsing for neon DI generation.

Consider this example:
sampleView:
    class: \View\ComponentView('samplename',[ data = @dataProvider::retrieveData() ])

Right now, the "@dataProvider::retrieveData()" is being considered a stdClass and is parsed " as is" - as a string. This little fix aims for seeking the scope recursively, parsing the call correctly.
