### PR TITLE
Http: raw request body retrieval method [BC Break]

### DIFF
--- a/Nette/Http/IRequest.php
+++ b/Nette/Http/IRequest.php
@@ -132,4 +132,10 @@ interface IRequest
 	 */
 	function getRemoteHost();
 
+	/**
+	 * Returns raw content of http request body or empty string.
+	 * @return string
+	 */
+	function getRawBody();
+
 }

--- a/Nette/Http/Request.php
+++ b/Nette/Http/Request.php
@@ -27,6 +27,7 @@ use Nette;
  * @property-read bool $ajax
  * @property-read string $remoteAddress
  * @property-read string $remoteHost
+ * @property-read string $rawBody
  */
 class Request extends Nette\Object implements IRequest
 {
@@ -56,6 +57,9 @@ class Request extends Nette\Object implements IRequest
 
 	/** @var string */
 	private $remoteHost;
+
+	/** @var string */
+	private $rawBody;
 
 
 	public function __construct(UrlScript $url, $query = NULL, $post = NULL, $files = NULL, $cookies = NULL,
@@ -287,6 +291,25 @@ class Request extends Nette\Object implements IRequest
 			$this->remoteHost = $this->remoteAddress ? getHostByAddr($this->remoteAddress) : NULL;
 		}
 		return $this->remoteHost;
+	}
+
+
+	/**
+	 * Returns raw content of http request body or empty string.
+	 * @return string
+	 */
+	public function getRawBody()
+	{
+		if ($this->rawBody === NULL) {
+			if (PHP_VERSION_ID >= 50600) {
+				return file_get_contents('php://input');
+			}
+			// The stream can be read only once in PHP < 5.6, see http://www.php.net/manual/en/wrappers.php.php
+			// and http://docs.php.net/manual/en/migration56.new-features.php
+			$this->rawBody = file_get_contents('php://input') ? : '';
+		}
+
+		return $this->rawBody;
 	}
 
 


### PR DESCRIPTION
It is useful to have possibility of raw request body retrieval for example in API request/response logger.

There are some cases in which stream php://input does not work as expected. See http://www.php.net/manual/en/wrappers.php.php for details. For example I read the stream in my REST API router to transform body to parameters. However I also have an event listener on `Application::onRequest` which logs complete HTTP request. So there is a problem with double reading from stream.

The BC break is there only because of change in `IRequest`. I think it should be there. It can be separted to its own commit so the main change can be cherry picked to earlier version then the commit with changed interface.

At the end I have absolutely no idea how to test this because the stream is read only.

If you think there should be different solution let me know.
