### PR TITLE
Dumper: Added support for __debugInfo (PHP 5.6 feature)

### DIFF
--- a/Nette/Diagnostics/Dumper.php
+++ b/Nette/Diagnostics/Dumper.php
@@ -212,6 +212,8 @@ class Dumper
 			foreach (clone $var as $obj) {
 				$fields[] = array('object' => $obj, 'data' => $var[$obj]);
 			}
+		} elseif (method_exists($var, '__debugInfo')) {
+			$fields = $var->__debugInfo();
 		} else {
 			$fields = (array) $var;
 		}


### PR DESCRIPTION
Adds support for [__debugInfo](https://wiki.php.net/rfc/debug-info) method which will will arrive with PHP 5.6.
It provides just a dumb conversion of the object before dumping, instead of casting to array.
(It's without test as I have no idea how to test such thing properly.)