### PR TITLE
DI: Smarter implicit value of $autowired in ServiceDefinition

### DIFF
--- a/Nette/DI/ServiceDefinition.php
+++ b/Nette/DI/ServiceDefinition.php
@@ -32,11 +32,8 @@ class ServiceDefinition extends Nette\Object
 	/** @var array */
 	public $tags = array();
 
-	/** @var mixed */
-	public $autowired = TRUE;
-
 	/** @var bool */
-	public $shared = TRUE;
+	public $autowired = TRUE;
 
 	/** @var bool */
 	public $inject = TRUE;
@@ -85,7 +82,6 @@ class ServiceDefinition extends Nette\Object
 
 	public function setParameters(array $params)
 	{
-		$this->shared = $this->autowired = FALSE;
 		$this->parameters = $params;
 		return $this;
 	}
@@ -100,7 +96,7 @@ class ServiceDefinition extends Nette\Object
 
 	public function setAutowired($on)
 	{
-		$this->autowired = $on;
+		$this->autowired = (bool) $on;
 		return $this;
 	}
 
@@ -108,8 +104,8 @@ class ServiceDefinition extends Nette\Object
 	/** @deprecated */
 	public function setShared($on)
 	{
-		$this->shared = (bool) $on;
-		$this->autowired = $this->shared ? $this->autowired : FALSE;
+		trigger_error(__METHOD__ . ' is deprecated. Use setAutowired instead.', E_USER_DEPRECATED);
+		$this->autowired = $on ? $this->autowired : FALSE;
 		return $this;
 	}
 
@@ -124,7 +120,6 @@ class ServiceDefinition extends Nette\Object
 	public function setImplement($implement)
 	{
 		$this->implement = $implement;
-		$this->shared = TRUE;
 		return $this;
 	}
 

--- a/tests/Nette/DI/Compiler.generatedFactory.phpt
+++ b/tests/Nette/DI/Compiler.generatedFactory.phpt
@@ -110,7 +110,6 @@ class TestExtension extends DI\CompilerExtension
 			->setImplement('IFooFactory')
 			->setArguments(array($builder::literal('$baz')));
 
-		// needed order: parameters, implement because of setting shared = true
 		// see definition by config in Compiler::parseService()
 	}
 }


### PR DESCRIPTION
Now it doesn't disable "autowired" when you set parameters for generated factory.
