### PR TITLE
DI: blacklist of classes excluded from autowiring

### DIFF
--- a/Nette/DI/Compiler.php
+++ b/Nette/DI/Compiler.php
@@ -65,6 +65,9 @@ class Compiler extends Nette\Object
 	 */
 	public function getContainerBuilder()
 	{
+		if ($this->builder === NULL) {
+			$this->builder = new ContainerBuilder();
+		}
 		return $this->builder;
 	}
 
@@ -85,7 +88,7 @@ class Compiler extends Nette\Object
 	public function compile(array $config, $className, $parentName)
 	{
 		$this->config = $config;
-		$this->builder = new ContainerBuilder;
+		$this->builder = $this->getContainerBuilder();
 		$this->processParameters();
 		$this->processExtensions();
 		$this->processServices();

--- a/Nette/DI/ContainerBuilder.php
+++ b/Nette/DI/ContainerBuilder.php
@@ -44,6 +44,9 @@ class ContainerBuilder extends Nette\Object
 	/** @var string */
 	/*private in 5.4*/public $currentService;
 
+	/** @var array of classes excluded from auto-wiring */
+	private $classBlacklist = array();
+
 
 	/**
 	 * Adds new service definition.
@@ -284,6 +287,10 @@ class ContainerBuilder extends Nette\Object
 					$this->classes[strtolower($parent)][] = (string) $name;
 				}
 			}
+		}
+
+		foreach ($this->classBlacklist as $class) {
+			unset($this->classes[$class]);
 		}
 
 		foreach ($this->classes as $class => $foo) {
@@ -703,6 +710,18 @@ class ContainerBuilder extends Nette\Object
 			throw new ServiceCreationException("Reference to missing service '$service'.");
 		}
 		return $service;
+	}
+
+
+	/**
+	 * @param string
+	 */
+	public function addClassToBlacklist($class)
+	{
+		$class = strtolower(trim($class, '\\'));
+		if(!in_array($class, $this->classBlacklist)) {
+			$this->classBlacklist[] = $class;
+		}
 	}
 
 }

--- a/Nette/common/Configurator.php
+++ b/Nette/common/Configurator.php
@@ -24,6 +24,18 @@ class Configurator extends Object
 	const AUTO = TRUE,
 		NONE = FALSE;
 
+	/** @var array of Nette classes which shouldn't be autowired */
+	public $autowiringClassBlacklist = array(
+		'Nette\ComponentModel\IComponent',
+		'Nette\ComponentModel\IContainer',
+		'Nette\ComponentModel\Component',
+		'Nette\ComponentModel\Container',
+		'Nette\Application\UI\Control',
+		'Nette\Application\UI\PresenterComponent',
+		'Nette\Application\UI\Presenter',
+		'Nette\Object',
+	);
+
 	/** @var array of function(Configurator $sender, DI\Compiler $compiler); Occurs after the compiler is created */
 	public $onCompile;
 
@@ -226,6 +238,9 @@ class Configurator extends Object
 
 		foreach ($this->defaultExtensions as $name => $class) {
 			$compiler->addExtension($name, new $class);
+		}
+		foreach ($this->autowiringClassBlacklist as $class) {
+			$compiler->getContainerBuilder()->addClassToBlacklist($class);
 		}
 
 		return $compiler;

--- a/tests/Nette/DI/Configurator.autowiringBlacklist.phpt
+++ b/tests/Nette/DI/Configurator.autowiringBlacklist.phpt
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Test: Nette\Configurator and autowiring blacklist
+ *
+ * @author     David Matejka
+ */
+
+use Nette\Configurator,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+class FooPresenter extends \Nette\Application\UI\Presenter
+{
+
+}
+
+
+$configurator = new Configurator;
+$configurator->setTempDirectory(TEMP_DIR);
+
+$container = $configurator->addConfig('files/configurator.autowiringBlacklist.neon')
+						  ->createContainer();
+
+
+Assert::type('FooPresenter', $container->getByType('FooPresenter'));
+Assert::exception(function () use ($container) {
+	$container->getByType('Nette\Application\UI\Presenter');
+}, '\Nette\DI\MissingServiceException');

--- a/tests/Nette/DI/ContainerBuilder.autowiring.blacklist.phpt
+++ b/tests/Nette/DI/ContainerBuilder.autowiring.blacklist.phpt
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Test: Nette\DI\ContainerBuilder and class blacklist
+ *
+ * @author     David Matejka
+ */
+
+use Nette\DI,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+interface Foo
+{
+
+}
+
+interface Ipsum
+{
+
+}
+
+class Bar
+{
+
+}
+
+class Lorem extends Bar implements Foo, Ipsum
+{
+
+}
+
+
+$builder = new DI\ContainerBuilder;
+$builder->addDefinition('lorem')
+		->setClass('Lorem');
+$builder->addClassToBlacklist('Foo');
+$builder->addClassToBlacklist('Bar');
+$code = implode('', $builder->generateClasses());
+file_put_contents(TEMP_DIR . '/code.php', "<?php\n$code");
+require TEMP_DIR . '/code.php';
+
+$container = new Container;
+
+Assert::type('Lorem', $container->getByType('Lorem'));
+Assert::type('Lorem', $container->getByType('Ipsum'));
+
+Assert::exception(function () use ($container) {
+	$container->getByType('Foo');
+}, '\Nette\DI\MissingServiceException');
+
+Assert::exception(function () use ($container) {
+	$container->getByType('Bar');
+}, '\Nette\DI\MissingServiceException');

--- a/tests/Nette/DI/files/configurator.autowiringBlacklist.neon
+++ b/tests/Nette/DI/files/configurator.autowiringBlacklist.neon
@@ -1,0 +1,2 @@
+services:
+	- FooPresenter


### PR DESCRIPTION
This prevents from autowiring generic typehints like IContainer.

example: You have some component (in my case it was visual paginator) and factory interface. You register that factory in DI container. Then you register some presenter in DI container. Because VisualPaginator has constructor from ComponentModel\Component (`__construct(IContainer $parent = NULL`...), nette tries to autowire presenter. And this may cause serious problems. This PR excludes Component, Container etc. from autowiring. Of course, you still can autowire all descendants which are not blacklisted. (so you cannot autowire UI\Presenter but you can autowire FooPresenter)

As a side effect, this PR shrinks down the size of generated container :)
