### PR TITLE
Session - moved regeneration of session ID to individual method

### DIFF
--- a/Nette/Http/Session.php
+++ b/Nette/Http/Session.php
@@ -85,7 +85,7 @@ class Session extends Nette\Object
 		$this->configure($this->options);
 
 		$id = & $_COOKIE[session_name()];
-		if (!!$this->checkId($id)) {
+		if (!$this->checkId($id)) {
 			unset($_COOKIE[session_name()]);
 		}
 
@@ -229,7 +229,7 @@ class Session extends Nette\Object
 			}
 			$this->changeId();
 			$newId = session_id();
-			if ( !$this->checkId($newId)){
+			if (!$this->checkId($newId)){
 				throw new Nette\InvalidStateException("Session ID '$newId' is not valid session identifier.");
 			}
 			session_write_close();

--- a/Nette/Http/Session.php
+++ b/Nette/Http/Session.php
@@ -85,7 +85,7 @@ class Session extends Nette\Object
 		$this->configure($this->options);
 
 		$id = & $_COOKIE[session_name()];
-		if (!is_string($id) || !preg_match('#^[0-9a-zA-Z,-]{22,128}\z#i', $id)) {
+		if (!!$this->checkId($id)) {
 			unset($_COOKIE[session_name()]);
 		}
 
@@ -227,7 +227,11 @@ class Session extends Nette\Object
 			if (headers_sent($file, $line)) {
 				throw new Nette\InvalidStateException("Cannot regenerate session ID after HTTP headers have been sent" . ($file ? " (output started at $file:$line)." : "."));
 			}
-			session_regenerate_id(TRUE);
+			$this->changeId();
+			$newId = session_id();
+			if ( !$this->checkId($newId)){
+				throw new Nette\InvalidStateException("Session ID '$newId' is not valid session identifier.");
+			}
 			session_write_close();
 			$backup = $_SESSION;
 			session_start();
@@ -237,6 +241,21 @@ class Session extends Nette\Object
 		$this->regenerated = TRUE;
 	}
 
+	/**
+	 * Performs change of session ID.
+	 */
+	protected function changeId() {
+		session_regenerate_id(TRUE);
+	}
+
+	/**
+	 * Checks that session ID has correct format.
+	 * @param string $id
+	 * @return bool
+	 */
+	private function checkId($id){
+		return is_string($id) && preg_match('#^[0-9a-zA-Z,-]{22,128}\z#i', $id);
+	}
 
 	/**
 	 * Returns the current session ID. Don't make dependencies, can be changed for each request.

--- a/Nette/Http/Session.php
+++ b/Nette/Http/Session.php
@@ -228,10 +228,6 @@ class Session extends Nette\Object
 				throw new Nette\InvalidStateException("Cannot regenerate session ID after HTTP headers have been sent" . ($file ? " (output started at $file:$line)." : "."));
 			}
 			$this->changeId();
-			$newId = session_id();
-			if (!$this->checkId($newId)){
-				throw new Nette\InvalidStateException("Session ID '$newId' is not valid session identifier.");
-			}
 			session_write_close();
 			$backup = $_SESSION;
 			session_start();
@@ -244,16 +240,18 @@ class Session extends Nette\Object
 	/**
 	 * Performs change of session ID.
 	 */
-	protected function changeId() {
+	protected function changeId()
+	{
 		session_regenerate_id(TRUE);
 	}
 
 	/**
 	 * Checks that session ID has correct format.
-	 * @param string $id
+	 * @param  string
 	 * @return bool
 	 */
-	private function checkId($id){
+	private function checkId($id)
+	{
 		return is_string($id) && preg_match('#^[0-9a-zA-Z,-]{22,128}\z#i', $id);
 	}
 


### PR DESCRIPTION
I needed to generate session ID in my own way, so I moved call of session_regenerate_id() to protected method. Now it is possible to override creation and setting of session ID.

Also added check if newly generated session ID is in correct format.