### PR TITLE
Debugger: pop-up does not break pages without html output

### DIFF
--- a/Nette/Diagnostics/templates/bar.js
+++ b/Nette/Diagnostics/templates/bar.js
@@ -112,7 +112,7 @@
 		}
 
 		var doc = win.document;
-		doc.write('<!DOCTYPE html><meta charset="utf-8"><style>' + $('#nette-debug-style').dom().innerHTML + '<\/style><script>' + $('#nette-debug-script').dom().innerHTML + '<\/script><body id="nette-debug">');
+		doc.write('<' + '!DOCTYPE html><meta charset="utf-8"><style>' + $('#nette-debug-style').dom().innerHTML + '<\/style><script>' + $('#nette-debug-script').dom().innerHTML + '<\/script><' + 'body id="nette-debug">');
 		doc.body.innerHTML = '<div class="nette-panel nette-mode-window" id="' + this.id + '">' + this.elem.dom().innerHTML + '<\/div>';
 		var winPanel = win.Nette.Debug.getPanel(this.id);
 		win.Nette.Dumper.init();


### PR DESCRIPTION
Browser (chrome 30+, FF) sometimes takes JS from pop-up as start of HTML, if there is no html output on page and debug bar code is dumped instead of rendering.
