### PR TITLE
Database: Condition can be written to the LEFT JOIN using Selection::left()

### DIFF
--- a/Nette/Database/Table/Selection.php
+++ b/Nette/Database/Table/Selection.php
@@ -341,7 +341,8 @@ class Selection extends Nette\Object implements \Iterator, IRowContainer, \Array
 	 * @param  mixed ...
 	 * @return self
 	 */
-	public function where($condition, $parameters = array()) {
+	public function where($condition, $parameters = array())
+	{
 		$args = func_get_args();
 		array_unshift($args, 'where');
 		return call_user_func_array($this->condition, $args);
@@ -354,7 +355,8 @@ class Selection extends Nette\Object implements \Iterator, IRowContainer, \Array
 	 * @param  mixed ...
 	 * @return self
 	 */
-	public function left($condition, $parameters = array()) {
+	public function left($condition, $parameters = array())
+	{
 		$args = func_get_args();
 		array_unshift($args, 'left');
 		return call_user_func_array($this->condition, $args);

--- a/Nette/Database/Table/SqlBuilder.php
+++ b/Nette/Database/Table/SqlBuilder.php
@@ -195,13 +195,15 @@ class SqlBuilder extends Nette\Object
 		return $this->select;
 	}
 
-	public function addLeft() {
+	public function addLeft()
+	{
 		$args = func_get_args();
 		array_unshift($args, 'left');
 		return call_user_func_array($this->addCondition, $args);
 	}
 
-	public function addWhere() {
+	public function addWhere()
+	{
 		$args = func_get_args();
 		array_unshift($args, 'where');
 		return call_user_func_array($this->addCondition, $args);
@@ -461,7 +463,7 @@ class SqlBuilder extends Nette\Object
 			list($joinTable, $joinAlias, $table, $tableColumn, $joinColumn) = $join;
 
 			$additionalConditions = '';
-			if(isset($leftConditions[$joinAlias]) && count($leftConditions[$joinAlias])){
+			if (isset($leftConditions[$joinAlias]) && count($leftConditions[$joinAlias])) {
 				$additionalConditions = ' AND (' . $leftConditions[$joinAlias] . ')';
 			}
 			
@@ -495,18 +497,20 @@ class SqlBuilder extends Nette\Object
 		return $return;
 	}
 	
-	protected function createLeftJoinConditions() {
+	protected function createLeftJoinConditions()
+	{
 		return implode(',', $this->left);
 	}
 	
-	protected function buildLeftJoinConditions($allLeftJoinConditions) {
+	protected function buildLeftJoinConditions($allLeftJoinConditions)
+	{
 		$conditions = array();
-		foreach(explode(',', $allLeftJoinConditions) as $condition){
+		foreach (explode(',', $allLeftJoinConditions) as $condition) {
 			$condition = Strings::trim($condition);
 			$table = Strings::replace($condition, '~\..*$~');
-			if(!isset($conditions[$table])){
+			if (!isset($conditions[$table])) {
 				$conditions[$table] = $condition;
-			}else{
+			} else {
 				$conditions[$table] .= " AND " . $condition;
 			}
 		}

--- a/tests/Nette/Database/Table/SqlBuilder.buildQueryJoins().phpt
+++ b/tests/Nette/Database/Table/SqlBuilder.buildQueryJoins().phpt
@@ -3,7 +3,7 @@
 /**
  * Test: Nette\Database\Table\SqlBuilder: parseJoins().
  *
- * @author     Jan Skrasek
+ * @author     Svaťa Šimara
  * @dataProvider? ../databases.ini
  */
 
@@ -26,34 +26,38 @@ class SqlBuilderMock extends SqlBuilder
 	{
 		return parent::buildQueryJoins($joins, $leftConditions);
 	}
+	public function buildLeftJoinConditions($allLeftJoinConditions) {
+		return parent::buildLeftJoinConditions($allLeftJoinConditions);
+	}
 }
 
 $reflection = new DiscoveredReflection($connection);
 $sqlBuilder = new SqlBuilderMock('nUsers', $connection, $reflection);
 
-
 $joins = array();
-$query = 'WHERE :nusers_ntopics.topic.priorit.id IS NULL';
-$sqlBuilder->parseJoins($joins, $query);
-$join = $sqlBuilder->buildQueryJoins($joins);
-Assert::same('WHERE priorit.id IS NULL', $query);
+$leftJoin = ':nusers_ntopics.topic.priorit.id IS NOT NULL, :nusers_ntopics.topic.priorit.id = ?';
+$sqlBuilder->parseJoins($joins, $leftJoin);
+$leftConditions = $sqlBuilder->buildLeftJoinConditions($leftJoin);
+$join = $sqlBuilder->buildQueryJoins($joins, $leftConditions);
+Assert::same('priorit.id IS NOT NULL AND priorit.id = ?', $leftConditions['priorit']);
 
 $tables = $connection->getSupplementalDriver()->getTables();
 if (!in_array($tables[0]['name'], array('npriorities', 'ntopics', 'nusers', 'nusers_ntopics', 'nusers_ntopics_alt'), TRUE)) {
 	Assert::same(
 		'LEFT JOIN nUsers_nTopics AS nusers_ntopics ON nUsers.nUserId = nusers_ntopics.nUserId ' .
 		'LEFT JOIN nTopics AS topic ON nusers_ntopics.nTopicId = topic.nTopicId ' .
-		'LEFT JOIN nPriorities AS priorit ON topic.nPriorityId = priorit.nPriorityId',
+		'LEFT JOIN nPriorities AS priorit ON topic.nPriorityId = priorit.nPriorityId AND (priorit.id IS NOT NULL AND priorit.id = ?)',
 		trim($join)
 	);
 } else {
 	Assert::same(
 		'LEFT JOIN nusers_ntopics ON nUsers.nUserId = nusers_ntopics.nUserId ' .
 		'LEFT JOIN ntopics AS topic ON nusers_ntopics.nTopicId = topic.nTopicId ' .
-		'LEFT JOIN npriorities AS priorit ON topic.nPriorityId = priorit.nPriorityId',
+		'LEFT JOIN npriorities AS priorit ON topic.nPriorityId = priorit.nPriorityId AND (priorit.id IS NOT NULL AND priorit.id = ?)',
 		trim($join)
 	);
 }
+
 
 
 Nette\Database\Helpers::loadFromFile($connection, __DIR__ . "/../files/{$driverName}-nette_test1.sql");
@@ -61,11 +65,12 @@ Nette\Database\Helpers::loadFromFile($connection, __DIR__ . "/../files/{$driverN
 $sqlBuilder = new SqlBuilderMock('author', $connection, $reflection);
 
 $joins = array();
-$query = 'WHERE :book(translator).next_volume IS NULL';
-$sqlBuilder->parseJoins($joins, $query);
-$join = $sqlBuilder->buildQueryJoins($joins);
-Assert::same('WHERE book.next_volume IS NULL', $query);
+$leftJoin = ':book(translator).next_volume = ? OR :book(translator).next_volume IS NULL';
+$sqlBuilder->parseJoins($joins, $leftJoin);
+$leftConditions = $sqlBuilder->buildLeftJoinConditions($leftJoin);
+$join = $sqlBuilder->buildQueryJoins($joins, $leftConditions);
+Assert::same('book.next_volume = ? OR book.next_volume IS NULL', $leftConditions['book']);
 Assert::same(
-	'LEFT JOIN book ON author.id = book.translator_id',
+	'LEFT JOIN book ON author.id = book.translator_id AND (book.next_volume = ? OR book.next_volume IS NULL)',
 	trim($join)
 );

--- a/tests/Nette/Database/Table/Table.left-join.phpt
+++ b/tests/Nette/Database/Table/Table.left-join.phpt
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Test: Nette\Database\Table: Join.
+ *
+ * @author     Svaťa Šimara
+ * @dataProvider? ../databases.ini
+ */
+
+use Tester\Assert;
+
+require __DIR__ . '/../connect.inc.php'; // create $connection
+
+Nette\Database\Helpers::loadFromFile($connection, __DIR__ . "/../files/{$driverName}-nette_test1.sql");
+
+
+test(function() use ($context) {
+	$sql = $context->table('book')->left('translator.name', 'Geek')->select('book.*')->getSql();
+	Assert::same(reformat('SELECT [book].* FROM [book] LEFT JOIN [author] AS [translator] ON [book].[translator_id] = [translator].[id] AND ([translator].[name] = ?)'), $sql);
+});
+
+test(function() use ($context){
+	$sql = $context->table('book')->left(':product_price.active', 1)->select('book.*, :product_price.value')->getSql();
+	Assert::same(reformat('SELECT [book].*, [product_price].[value] FROM [book] LEFT JOIN [product_price] ON [book].[id] = [product_price].[book_id] AND ([product_price].[active] = ?)'), $sql);
+});
+
+test(function() use ($context){
+	$sql = $context->table('book')
+		->left(':product_price.active', 1)
+		->where(':book_tag.tag.name LIKE', 'PHP')
+		->left(':product_price.value > ?', 0)
+		->left(':book_tag.tag_id IS NOT NULL')
+		->select('book.*, :product_price.value')->getSql();
+	Assert::same(reformat(
+		'SELECT [book].*, [product_price].[value] FROM [book]'
+		. ' LEFT JOIN [book_tag] ON [book].[id] = [book_tag].[book_id] AND ([book_tag].[tag_id] IS NOT NULL)'
+		. ' LEFT JOIN [tag] ON [book_tag].[tag_id] = [tag].[id]'
+		. ' LEFT JOIN [product_price] ON [book].[id] = [product_price].[book_id] AND ([product_price].[active] = ? AND [product_price].[value] > ?)'
+		. ' WHERE ([tag].[name] LIKE ?)'), $sql);
+});

--- a/tests/Nette/Database/files/mysql-nette_test1.sql
+++ b/tests/Nette/Database/files/mysql-nette_test1.sql
@@ -95,4 +95,17 @@ CREATE TABLE note (
 	CONSTRAINT note_book FOREIGN KEY (book_id) REFERENCES book (id)
 );
 
+CREATE TABLE product_price (
+	id INT NOT NULL AUTO_INCREMENT,
+	book_id INT NOT NULL,
+	value DOUBLE NOT NULL,
+	active TINYINT(1) NOT NULL,
+	PRIMARY KEY (id),
+	CONSTRAINT book_product_price FOREIGN KEY (book_id) REFERENCES book (id)
+);
+
+INSERT INTO product_price (book_id, value, active) VALUES (1, 1000, 1);
+INSERT INTO product_price (book_id, value, active) VALUES (2, 500, 1);
+INSERT INTO product_price (book_id, value, active) VALUES (3, 666, 0);
+
 SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
There is a one thing that we are missing, and it's a left join support in selection.
This pull request is just a draft, but it is quite importat for us (not this code, but function).

Common situation: You have a product (book) and it's price in another table (product_price). Price can be active or inactive (historical price). When product doesn't have active price, and you are selecting books it's prices, you need left join if you want to see all books.

So, we would like to call:
```php
$db->table('book')
->select('book.*, :product_price.value')
->left(':product_price.active', 1);