### PR TITLE
Forms: setAction method gets element through getElementPrototype method

### DIFF
--- a/Nette/Forms/Form.php
+++ b/Nette/Forms/Form.php
@@ -173,7 +173,7 @@ class Form extends Container
 	 */
 	public function setAction($url)
 	{
-		$this->element->action = $url;
+		$this->getElementPrototype()->action = $url;
 		return $this;
 	}
 


### PR DESCRIPTION
It has been broken in #1404
