### PR TITLE
NEON parser: fixed replacing special keywords for keys&test [Closes #809]

### DIFF
--- a/Nette/Utils/Neon.php
+++ b/Nette/Utils/Neon.php
@@ -176,6 +176,11 @@ class Neon extends Nette\Object
 		for (; $n < $count; $n++) {
 			$t = $tokens[$n][0];
 
+			$nextT = NULL;
+			if(isset($tokens[$n+1][0])) {
+				$nextT = $tokens[$n+1][0];
+			}
+			
 			if ($t === ',') { // ArrayEntry separator
 				if ((!$hasKey && !$hasValue) || !$inlineParser) {
 					$this->error();
@@ -292,7 +297,7 @@ class Neon extends Nette\Object
 					$value = preg_replace_callback('#\\\\(?:u[0-9a-f]{4}|x[0-9a-f]{2}|.)#i', array($this, 'cbString'), substr($t, 1, -1));
 				} elseif ($t[0] === "'") {
 					$value = substr($t, 1, -1);
-				} elseif (isset($consts[$t])) {
+				} elseif (isset($consts[$t]) && !($nextT === ':' || $nextT === '=')) {
 					$value = $consts[$t];
 				} elseif ($t === 'null' || $t === 'Null' || $t === 'NULL') {
 					$value = NULL;

--- a/tests/Nette/Utils/Neon.decode.inline.array.phpt
+++ b/tests/Nette/Utils/Neon.decode.inline.array.phpt
@@ -24,11 +24,11 @@ Assert::same( array(
 
 
 Assert::same( array(
-	1 => 1,
-	'' => 1,
+	'false' => false,
+	'on' => true,
 	-5 => 1,
 	'5.3' => 1,
-), Neon::decode('{true: 1, false: 1, -5: 1, 5.3: 1}') );
+), Neon::decode('{false: off, "on": true, -5: 1, 5.3: 1}') );
 
 
 Assert::same( array(


### PR DESCRIPTION
NEON parser will not convert special keywords as true, false, on,.. to special values in keys or array.
In values function special keywords replacement is preserved.

```
parameters:
true: true
```

will be parsed as:

```
parameters{
"true"=> TRUE
}
```

instead of wrong:

```
parameters{
1 => TRUE
}
```
