### PR TITLE
Latte\Parser: fixed macro's inner subpattern

### DIFF
--- a/Nette/Latte/Parser.php
+++ b/Nette/Latte/Parser.php
@@ -308,9 +308,11 @@ class Parser extends Nette\Object
 		$this->macroRe = '
 			(?P<comment>' . $left . '\\*.*?\\*' . $right . '\n{0,2})|
 			' . $left . '
-				(?P<macro>(?:' . self::RE_STRING . '|\{
-						(?P<inner>' . self::RE_STRING . '|\{(?P>inner)\}|[^\'"{}])*+
-				\}|[^\'"{}])+?)
+				(?P<macro>(?:
+					' . self::RE_STRING . '|
+					\{(?:' . self::RE_STRING . '|[^\'"{}])*+\}|
+					[^\'"{}]
+				)+?)
 			' . $right . '
 			(?P<rmargin>[ \t]*(?=\n))?
 		';


### PR DESCRIPTION
Funny thing happened. I was hating Latte on Twitter for being to complicated to be lexical analyzed by finite-state machine due to macro-token recursive nature which requires bracket counting and matching. But then I closely looked at the corresponding subpattern and realize that there is actually a bug because the `inner` subpattern does contain the `*` making it pretty much useless.

For example the input `{x {x {x {x} } } }` is now recognized as single token which failed previously. 

![Regular expression visualization](https://www.debuggex.com/i/ktILn0UFeyRhrD6r.png)

[Visualization of simplified regular expression with debuggex](https://www.debuggex.com/r/ktILn0UFeyRhrD6r)
