### PR TITLE
Option to disable autoloading of annotation classes

### DIFF
--- a/Nette/Reflection/AnnotationsParser.php
+++ b/Nette/Reflection/AnnotationsParser.php
@@ -28,6 +28,9 @@ class AnnotationsParser
 	/** @var bool */
 	public static $useReflection;
 
+	/** @var bool */
+	public static $useAnnotationClasses = TRUE;
+
 	/** @var array */
 	public static $inherited = array('description', 'param', 'return');
 
@@ -248,7 +251,7 @@ class AnnotationsParser
 			}
 
 			$class = $name . 'Annotation';
-			if (class_exists($class)) {
+			if (self::$useAnnotationClasses && class_exists($class)) {
 				$res[$name][] = new $class(is_array($value) ? $value : array('value' => $value));
 
 			} else {


### PR DESCRIPTION
The ability of loading custom annotation classes is not widely used and since it can have a significant impact on performance (heavy usage of annotations + several autoloaders + multiple attempts to load the same annotation), it would be great to have an option to disable this behaviour.
