### PR TITLE
More helpful exception message when a parameter in DI config is missing

### DIFF
--- a/Nette/DI/Helpers.php
+++ b/Nette/DI/Helpers.php
@@ -59,7 +59,11 @@ class Helpers
 				throw new Nette\InvalidArgumentException('Circular reference detected for variables: ' . implode(', ', array_keys($recursive)) . '.');
 
 			} else {
-				$val = Nette\Utils\Arrays::get($params, explode('.', $part));
+				try {
+					$val = Nette\Utils\Arrays::get($params, explode('.', $part));
+				} catch (Nette\InvalidArgumentException $e) {
+					throw new Nette\InvalidArgumentException("Missing parameter '$part'.", 0, $e);
+				}
 				if ($recursive) {
 					$val = self::expand($val, $params, (is_array($recursive) ? $recursive : array()) + array($part => 1));
 				}

--- a/tests/Nette/DI/Container.expand.phpt
+++ b/tests/Nette/DI/Container.expand.phpt
@@ -24,7 +24,11 @@ Assert::same( array('cache' => '/temp'), $container->expand('%dirs%') );
 
 Assert::exception(function() use ($container) {
 	$container->expand('%bar%');
-}, 'Nette\InvalidArgumentException', "Missing item 'bar'.");
+}, 'Nette\InvalidArgumentException', "Missing parameter 'bar'.");
+
+Assert::exception(function() use ($container) {
+	$container->expand('%foo.bar%');
+}, 'Nette\InvalidArgumentException', "Missing parameter 'foo.bar'.");
 
 Assert::exception(function() use ($container) {
 	$container->parameters['bar'] = array();

--- a/tests/Nette/DI/Helpers.expand().phpt
+++ b/tests/Nette/DI/Helpers.expand().phpt
@@ -33,7 +33,7 @@ Assert::same(
 
 Assert::exception(function() {
 	Helpers::expand('%missing%', array());
-}, 'Nette\InvalidArgumentException', "Missing item 'missing'.");
+}, 'Nette\InvalidArgumentException', "Missing parameter 'missing'.");
 
 Assert::exception(function() {
 	Helpers::expand('%key1%a', array('key1' => array('key2' => 123)));


### PR DESCRIPTION
Exception message from `Arrays::get` is not very helpful when expanding parameters such as `%foo.bar%` (reports that `bar` is missing) and sometimes can be even misleading.
