### PR TITLE
iconv_set_encoding() is deprecated since 5.6.0

### DIFF
--- a/Nette/loader.php
+++ b/Nette/loader.php
@@ -23,7 +23,7 @@ if (PHP_VERSION_ID < 50200) {
 
 error_reporting(E_ALL | E_STRICT);
 @set_magic_quotes_runtime(FALSE); // @ - deprecated since PHP 5.3.0
-iconv_set_encoding('internal_encoding', 'UTF-8');
+@iconv_set_encoding('internal_encoding', 'UTF-8'); // @ - deprecated since 5.6.0
 extension_loaded('mbstring') && mb_internal_encoding('UTF-8');
 umask(0);
 @header('X-Powered-By: Nette Framework'); // @ - headers may be sent


### PR DESCRIPTION
5.6.0 breaks loader.php in Nette 2.0
See https://wiki.php.net/rfc/default_encoding or https://github.com/php/php-src/commit/cbd108abf19d9fb9ae1d4ccd153215f56a2763e8
