### PR TITLE
Added parameter to iconv_mime_encode

### DIFF
--- a/Nette/Mail/MimePart.php
+++ b/Nette/Mail/MimePart.php
@@ -316,6 +316,7 @@ class MimePart extends Nette\Object
 			'scheme' => 'B', // Q is broken
 			'input-charset' => 'UTF-8',
 			'output-charset' => 'UTF-8',
+			'line-length' => self::LINE_LENGTH,
 		));
 
 		$offset = strlen($s) - strrpos($s, "\n");


### PR DESCRIPTION
When line length is modified, this parameter wasn't transferred in iconv_mime_encode function and header was wrong encoded.
